### PR TITLE
PHP: adding persistent channel management for php-fpm mode

### DIFF
--- a/src/php/ext/grpc/build.sh
+++ b/src/php/ext/grpc/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+make clean
+make

--- a/src/php/ext/grpc/channel.c
+++ b/src/php/ext/grpc/channel.c
@@ -215,21 +215,22 @@ void print_timespec(gpr_timespec* time_spec){
 gpr_timespec* grpc_php_time_copy(gpr_timespec* tv1, gpr_timespec tv2){
   tv1->tv_sec = tv2.tv_sec;
   tv1->tv_nsec = tv2.tv_nsec;
+  tv1->clock_type = tv2.clock_type;
   return tv1;
 }
 void update_time_key_persistent_list(channel_persistent_le_t* le) {
-//  php_printf("update_time_key_persistent_list\n");
-//  gpr_timespec* tv1 = (gpr_timespec *)pemalloc(sizeof(gpr_timespec), 1);
-//  grpc_php_time_copy(tv1, gpr_now(GPR_CLOCK_REALTIME));
-//
-//  le->time = tv1;
-//  print_timespec(le->time);
-//  usleep(500*1000);
-//  gpr_timespec* tv2 = (gpr_timespec *)pemalloc(sizeof(gpr_timespec), 1);
-//  grpc_php_time_copy(tv2, gpr_now(GPR_CLOCK_REALTIME));
-//  le->time = tv2;
-//  print_timespec(tv2);
-//  php_printf("time diff:::: %" PRId32 "\n", gpr_time_to_millis(gpr_time_sub(*tv2, *tv1)));
+  php_printf("update_time_key_persistent_list\n");
+  gpr_timespec* tv1 = (gpr_timespec *)pemalloc(sizeof(gpr_timespec), 1);
+  grpc_php_time_copy(tv1, gpr_now(GPR_CLOCK_REALTIME));
+
+  le->time = tv1;
+  print_timespec(le->time);
+  usleep(500*1000);
+  gpr_timespec* tv2 = (gpr_timespec *)pemalloc(sizeof(gpr_timespec), 1);
+  grpc_php_time_copy(tv2, gpr_now(GPR_CLOCK_REALTIME));
+  le->time = tv2;
+  print_timespec(tv2);
+  php_printf("time diff:::: %" PRId32 "\n", gpr_time_to_millis(gpr_time_sub(*tv2, *tv1)));
   grpc_time_key_map_update(&channel_register, le);
 }
 
@@ -506,6 +507,7 @@ PHP_METHOD(Channel, getTarget) {
  */
 PHP_METHOD(Channel, getConnectivityState) {
   php_printf("getConnectivityState start\n");
+  php_grpc_time_key_map_print(&channel_register);
   wrapped_grpc_channel *channel = Z_WRAPPED_GRPC_CHANNEL_P(getThis());
   gpr_mu_lock(&channel->wrapper->mu);
   if (channel->wrapper->wrapped == NULL) {

--- a/src/php/ext/grpc/channel.c
+++ b/src/php/ext/grpc/channel.c
@@ -251,7 +251,9 @@ void delete_timeout_from_time_key_persistent_list(gpr_timespec time_cur) {
               (php_grpc_time_key_map_size(&channel_register) == 0)) {
       break;
     }
-    php_grpc_time_key_map_delete(&channel_register, le);
+    if(le->ref_count == 0){
+      php_grpc_time_key_map_delete(&channel_register, le);
+    }
   }
 }
 
@@ -306,7 +308,7 @@ void create_and_add_channel_to_persistent_list(
 
   gpr_timespec channel_creation_time = gpr_now(GPR_CLOCK_REALTIME);
 
-  // delete_timeout_from_time_key_persistent_list(channel_creation_time);
+  delete_timeout_from_time_key_persistent_list(channel_creation_time);
   le = grpc_time_key_map_get_first_free(&channel_register);
   if(le != NULL) {
      php_printf("should use the first free of the persistent_list\n");

--- a/src/php/ext/grpc/channel.h
+++ b/src/php/ext/grpc/channel.h
@@ -86,8 +86,8 @@ typedef struct _channel_persistent_le {
   grpc_channel_wrapper *channel;
   double* time;
   size_t ref_count;
-  channel_persistent_le_t* next; // point to the next persistent channel who are newer than it.
-  channel_persistent_le_t* prev; // point to the next persistent channel who are older than it.
+  struct _channel_persistent_le* next; // point to the next persistent channel who are newer than it.
+  struct _channel_persistent_le* prev; // point to the next persistent channel who are older than it.
 } channel_persistent_le_t;
 
 

--- a/src/php/ext/grpc/channel.h
+++ b/src/php/ext/grpc/channel.h
@@ -84,6 +84,8 @@ void php_grpc_delete_persistent_list_entry(char *key, php_grpc_int key_len
 
 typedef struct _channel_persistent_le {
   grpc_channel_wrapper *channel;
+  double* time;
+  size_t ref_count;
 } channel_persistent_le_t;
 
 

--- a/src/php/ext/grpc/channel.h
+++ b/src/php/ext/grpc/channel.h
@@ -86,6 +86,8 @@ typedef struct _channel_persistent_le {
   grpc_channel_wrapper *channel;
   double* time;
   size_t ref_count;
+  channel_persistent_le_t* next; // point to the next persistent channel who are newer than it.
+  channel_persistent_le_t* prev; // point to the next persistent channel who are older than it.
 } channel_persistent_le_t;
 
 

--- a/src/php/ext/grpc/channel.h
+++ b/src/php/ext/grpc/channel.h
@@ -44,7 +44,7 @@ typedef struct _grpc_channel_wrapper {
   // before to avoid double free.
   bool is_valid;
   // ref_count is used to let the last wrapper free related channel and key.
-  size_t ref_count;
+//  size_t ref_count;
 } grpc_channel_wrapper;
 
 /* Wrapper struct for grpc_channel that can be associated with a PHP object */

--- a/src/php/ext/grpc/channel.h
+++ b/src/php/ext/grpc/channel.h
@@ -85,7 +85,7 @@ void php_grpc_delete_persistent_list_entry(char *key, php_grpc_int key_len
 typedef struct _channel_persistent_le {
   grpc_channel_wrapper *channel;
   double* time;
-  size_t ref_count;
+  size_t* ref_count;
   struct _channel_persistent_le* next; // point to the next persistent channel who are newer than it.
   struct _channel_persistent_le* prev; // point to the next persistent channel who are older than it.
 } channel_persistent_le_t;

--- a/src/php/ext/grpc/channel.h
+++ b/src/php/ext/grpc/channel.h
@@ -84,7 +84,7 @@ void php_grpc_delete_persistent_list_entry(char *key, php_grpc_int key_len
 
 typedef struct _channel_persistent_le {
   grpc_channel_wrapper *channel;
-  int32_t* time;
+  gpr_timespec* time;
   size_t* ref_count;
   struct _channel_persistent_le* next; // point to the next persistent channel who are newer than it.
   struct _channel_persistent_le* prev; // point to the next persistent channel who are older than it.

--- a/src/php/ext/grpc/channel.h
+++ b/src/php/ext/grpc/channel.h
@@ -84,7 +84,7 @@ void php_grpc_delete_persistent_list_entry(char *key, php_grpc_int key_len
 
 typedef struct _channel_persistent_le {
   grpc_channel_wrapper *channel;
-  double* time;
+  int32_t* time;
   size_t* ref_count;
   struct _channel_persistent_le* next; // point to the next persistent channel who are newer than it.
   struct _channel_persistent_le* prev; // point to the next persistent channel who are older than it.

--- a/src/php/ext/grpc/config.m4
+++ b/src/php/ext/grpc/config.m4
@@ -75,7 +75,7 @@ if test "$PHP_GRPC" != "no"; then
   PHP_SUBST(GRPC_SHARED_LIBADD)
 
   PHP_NEW_EXTENSION(grpc, byte_buffer.c call.c call_credentials.c channel.c \
-    channel_credentials.c completion_queue.c timeval.c server.c \
+    channel_credentials.c completion_queue.c map.c timeval.c server.c \
     server_credentials.c php_grpc.c, $ext_shared, , -Wall -Werror -std=c11)
 fi
 

--- a/src/php/ext/grpc/map.c
+++ b/src/php/ext/grpc/map.c
@@ -64,7 +64,7 @@ void php_grpc_time_key_map_destroy(php_grpc_time_key_map* map) {
   // TODO: free all capacity_remain first
   channel_persistent_le_t* cur = map->header;
   channel_persistent_le_t* tmp = NULL;
-  while(cur != map->tail){
+  while(cur != map->tail && cur != NULL){
     tmp = cur->next;
     pefree(cur, true);
     cur = tmp;
@@ -157,20 +157,21 @@ void php_grpc_time_key_map_print(php_grpc_time_key_map* map) {
   size_t i;
   channel_persistent_le_t* cur = map->header->next;
   for (i = 0; i < map->count; i++) {
-    php_printf("channel: %zu, time: %ld, target: %s, key: %s, ref_count: %zu\n", i, cur->time, cur->channel->target, cur->channel->key,
+    php_printf("channel: %zu, target: %s, key: %s, ref_count: %zu\n", i, cur->channel->target, cur->channel->key,
     *cur->ref_count);
     cur = cur->next;
     if(cur == NULL) php_printf("wrongggggggggggggggggggggggg\n");
   }
-  while(cur != map->tail){
-    php_printf("=======\n");
-    php_printf("channel: %zu, time: %ld, target: %s, key: %s, ref_count: %zu\n", i, cur->time, cur->channel->target, cur->channel->key,
-    *cur->ref_count);
-    cur = cur->next;
-  }
+//  while(cur != map->tail){
+//    php_printf("=======\n");
+//    php_printf("channel: %zu, target: %s, key: %s, ref_count: %zu\n", i, cur->channel->target, cur->channel->key,
+//    *cur->ref_count);
+//    cur = cur->next;
+//  }
 }
 
 void php_grpc_time_key_map_re_init_test(php_grpc_time_key_map* map){
+  map->count = 0;
   map->header->next = map->tail;
   map->tail->prev = map->header;
   map->tail->next = NULL;

--- a/src/php/ext/grpc/map.c
+++ b/src/php/ext/grpc/map.c
@@ -1,0 +1,369 @@
+/*
+ *
+ * Copyright 2015 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "map.h"
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <php.h>
+#include <php_ini.h>
+#include <ext/standard/info.h>
+#include <ext/spl/spl_exceptions.h>
+#include "php_grpc.h"
+
+#include <zend_exceptions.h>
+
+#include <stdbool.h>
+
+#include <grpc/grpc.h>
+#include <grpc/support/time.h>
+#include <grpc/support/port_platform.h>
+
+#include <string.h>
+
+#include <grpc/support/alloc.h>
+#include <grpc/support/log.h>
+
+void grpc_time_channel_key_map_init(grpc_time_channel_key_map* map,
+                                 size_t initial_capacity) {
+  GPR_ASSERT(initial_capacity > 1);
+  map->keys =
+      (double*)(gpr_malloc(sizeof(double) * initial_capacity));
+  map->values =
+      (void**)(gpr_malloc(sizeof(void*) * initial_capacity));
+  map->count = 0;
+  map->free = 0;
+  map->capacity = initial_capacity;
+}
+
+void grpc_time_channel_key_map_destroy(grpc_time_channel_key_map* map) {
+  gpr_free(map->keys);
+  gpr_free(map->values);
+}
+
+static size_t compact(double* keys, void** values, size_t count) {
+  size_t i, out;
+
+  for (i = 0, out = 0; i < count; i++) {
+    if (values[i]) {
+      keys[out] = keys[i];
+      values[out] = values[i];
+      out++;
+    }
+  }
+
+  return out;
+}
+
+void grpc_time_channel_key_map_add(grpc_time_channel_key_map* map, double key,
+                                void* value) {
+  size_t count = map->count;
+  size_t capacity = map->capacity;
+  double* keys = map->keys;
+  void** values = map->values;
+
+  GPR_ASSERT(count == 0 || keys[count - 1] < key);
+  GPR_ASSERT(value);
+  GPR_ASSERT(grpc_time_channel_key_map_find(map, key) == NULL);
+
+  if (count == capacity) {
+    if (map->free > capacity / 4) {
+      count = compact(keys, values, count);
+      map->free = 0;
+    } else {
+      /* resize when less than 25% of the table is free, because compaction
+         won't help much */
+      map->capacity = capacity = 3 * capacity / 2;
+      map->keys = keys = (double*)(
+          gpr_realloc(keys, capacity * sizeof(double)));
+      map->values = values =
+          (void**)(gpr_realloc(values, capacity * sizeof(void*)));
+    }
+  }
+
+  keys[count] = key;
+  values[count] = value;
+  map->count = count + 1;
+}
+
+static void** find(grpc_time_channel_key_map* map, double key) {
+  size_t min_idx = 0;
+  size_t max_idx = map->count;
+  size_t mid_idx;
+  double* keys = map->keys;
+  void** values = map->values;
+  double mid_key;
+
+  if (max_idx == 0) return NULL;
+
+  while (min_idx < max_idx) {
+    /* find the midpoint, avoiding overflow */
+    mid_idx = min_idx + ((max_idx - min_idx) / 2);
+    mid_key = keys[mid_idx];
+
+    if (mid_key < key) {
+      min_idx = mid_idx + 1;
+    } else if (mid_key > key) {
+      max_idx = mid_idx;
+    } else /* mid_key == key */
+    {
+      return &values[mid_idx];
+    }
+  }
+
+  return NULL;
+}
+
+void* grpc_time_channel_key_map_delete(grpc_time_channel_key_map* map, double key) {
+  void** pvalue = find(map, key);
+  void* out = NULL;
+  if (pvalue != NULL) {
+    out = *pvalue;
+    *pvalue = NULL;
+    map->free += (out != NULL);
+    /* recognize complete emptyness and ensure we can skip
+     * defragmentation later */
+    if (map->free == map->count) {
+      map->free = map->count = 0;
+    }
+    GPR_ASSERT(grpc_time_channel_key_map_find(map, key) == NULL);
+  }
+  return out;
+}
+
+void* grpc_time_channel_key_map_find(grpc_time_channel_key_map* map, double key) {
+  void** pvalue = find(map, key);
+  return pvalue != NULL ? *pvalue : NULL;
+}
+
+size_t grpc_time_channel_key_map_size(grpc_time_channel_key_map* map) {
+  return map->count - map->free;
+}
+
+void* grpc_time_channel_key_map_rand(grpc_time_channel_key_map* map) {
+  if (map->count == map->free) {
+    return NULL;
+  }
+  if (map->free != 0) {
+    map->count = compact(map->keys, map->values, map->count);
+    map->free = 0;
+    GPR_ASSERT(map->count > 0);
+  }
+  return map->values[((size_t)(rand())) % map->count];
+}
+
+void grpc_time_channel_key_map_for_each(grpc_time_channel_key_map* map,
+                                     void (*f)(void* user_data, double key,
+                                               void* value),
+                                     void* user_data) {
+  size_t i;
+
+  for (i = 0; i < map->count; i++) {
+    if (map->values[i]) {
+      f(user_data, map->keys[i], map->values[i]);
+    }
+  }
+}
+
+
+/*
+#include "map.h"
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <php.h>
+#include <php_ini.h>
+#include <ext/standard/info.h>
+#include <ext/spl/spl_exceptions.h>
+#include "php_grpc.h"
+
+#include <zend_exceptions.h>
+
+#include <stdbool.h>
+
+#include <grpc/grpc.h>
+#include <grpc/support/time.h>
+#include <grpc/support/port_platform.h>
+
+#include <string.h>
+
+#include <grpc/support/alloc.h>
+#include <grpc/support/log.h>
+
+void grpc_time_key_map_init(grpc_time_key_map* map,
+                                 size_t initial_capacity) {
+  GPR_ASSERT(initial_capacity > 1);
+  map->keys =
+      (double*)(pemalloc(sizeof(double) * initial_capacity, true));
+  map->values =
+      (void**)(pemalloc(sizeof(void*) * initial_capacity, true));
+  map->count = 0;
+  map->free = 0;
+  map->capacity = initial_capacity;
+}
+
+void grpc_time_key_map_destroy(grpc_time_key_map* map) {
+  pefree(map->keys, true);
+  pefree(map->values, true);
+}
+
+static size_t compact(double* keys, void** values, size_t count) {
+  size_t i, out;
+
+  for (i = 0, out = 0; i < count; i++) {
+    if (values[i]) {
+      keys[out] = keys[i];
+      values[out] = values[i];
+      out++;
+    }
+  }
+
+  return out;
+}
+
+void grpc_time_key_map_add(grpc_time_key_map* map, double key,
+                                void* value) {
+  size_t count = map->count;
+  size_t capacity = map->capacity;
+  double* keys = map->keys;
+  void** values = map->values;
+
+  GPR_ASSERT(count == 0 || keys[count - 1] < key);
+  GPR_ASSERT(value);
+  GPR_ASSERT(grpc_time_key_map_find(map, key) == NULL);
+
+  if (count == capacity) {
+    if (map->free > capacity / 4) {
+      count = compact(keys, values, count);
+      map->free = 0;
+    } else {
+      map->capacity = capacity = 3 * capacity / 2;
+      map->keys = keys = (double*)(
+          perealloc(keys, capacity * sizeof(double), true));
+      map->values = values =
+          (void**)(perealloc(values, capacity * sizeof(void*), true));
+    }
+  }
+
+  keys[count] = key;
+  values[count] = value;
+  map->count = count + 1;
+}
+
+static void** find(grpc_time_key_map* map, double key) {
+  size_t min_idx = 0;
+  size_t max_idx = map->count;
+  size_t mid_idx;
+  double* keys = map->keys;
+  void** values = map->values;
+  double mid_key;
+
+  if (max_idx == 0) return NULL;
+
+  while (min_idx < max_idx) {
+    mid_idx = min_idx + ((max_idx - min_idx) / 2);
+    mid_key = keys[mid_idx];
+
+    if (mid_key < key) {
+      min_idx = mid_idx + 1;
+    } else if (mid_key > key) {
+      max_idx = mid_idx;
+    } else
+    {
+      return &values[mid_idx];
+    }
+  }
+
+  return NULL;
+}
+
+void* grpc_time_key_map_delete(grpc_time_key_map* map, double key) {
+  void** pvalue = find(map, key);
+  void* out = NULL;
+  if (pvalue != NULL) {
+    out = *pvalue;
+    *pvalue = NULL;
+    map->free += (out != NULL);
+    if (map->free == map->count) {
+      map->free = map->count = 0;
+    }
+    GPR_ASSERT(grpc_time_key_map_find(map, key) == NULL);
+  }
+  return out;
+}
+
+void* grpc_time_key_map_find(grpc_time_key_map* map, double key) {
+  void** pvalue = find(map, key);
+  return pvalue != NULL ? *pvalue : NULL;
+}
+
+void* grpc_time_key_map_top(grpc_time_key_map* map) {
+  if (map->free == map->count) {
+    return NULL;
+  }
+  size_t i, out;
+  for (i = 0, out = 0; i < map->count; i++) {
+    if (map->values[i]) {
+      return map->key[i];
+    }
+  }
+  GPR_ASSERT(i != map->count);
+  return NULL;
+}
+
+void grpc_time_key_map_update(double time_pre, double time_cur, char* key){
+
+}
+//size_t grpc_time_key_map_delete_timeout(grpc_time_key_map* map, size_t index, double timeout, double current_time) {
+//  if (map->free == map->count) {
+//    return NULL;
+//  }
+//  void* value = map->values[index];
+//  if (*value != NULL) {
+//
+//  }
+//  size_t i, out;
+//  for (i = 0, out = 0; i < map->count; i++) {
+//    if (map->map->keys[i] + timeout > current_time) {
+//      return map->values[i];
+//    }
+//  }
+//  return NULL;
+//}
+
+size_t grpc_time_key_map_size(grpc_time_key_map* map) {
+  return map->count - map->free;
+}
+
+void grpc_time_key_map_for_each(grpc_time_key_map* map,
+                                     void (*f)(void* user_data, double key,
+                                               void* value),
+                                     void* user_data) {
+  size_t i;
+
+  for (i = 0; i < map->count; i++) {
+    if (map->values[i]) {
+      f(user_data, map->keys[i], map->values[i]);
+    }
+  }
+}
+*/

--- a/src/php/ext/grpc/map.c
+++ b/src/php/ext/grpc/map.c
@@ -44,130 +44,79 @@
 void grpc_time_channel_key_map_init(grpc_time_channel_key_map* map,
                                  size_t initial_capacity) {
   GPR_ASSERT(initial_capacity > 1);
-  map->keys =
-      (double*)(gpr_malloc(sizeof(double) * initial_capacity));
-  map->values =
-      (void**)(gpr_malloc(sizeof(void*) * initial_capacity));
+  map->header =
+      (channel_persistent_le_t*)(pemalloc(sizeof(channel_persistent_le_t) * 1));
+  map->tail =
+      (channel_persistent_le_t*)(pemalloc(sizeof(channel_persistent_le_t) * 1));
   map->count = 0;
-  map->free = 0;
   map->capacity = initial_capacity;
+  map->capacity_remain = 0;
 }
 
 void grpc_time_channel_key_map_destroy(grpc_time_channel_key_map* map) {
-  gpr_free(map->keys);
-  gpr_free(map->values);
+  // TODO: free all capacity_remain first
+  gpr_free(map->header);
+  gpr_free(map->tail);
 }
 
-static size_t compact(double* keys, void** values, size_t count) {
-  size_t i, out;
+void grpc_time_key_map_update(grpc_time_channel_key_map* map,
+                        channel_persistent_le_t le) {
+  le->prev->next = le->next;
+  le->next->prev = le->prev;
 
-  for (i = 0, out = 0; i < count; i++) {
-    if (values[i]) {
-      keys[out] = keys[i];
-      values[out] = values[i];
-      out++;
-    }
-  }
+  le->prev = tail->prev;
+  le->prev->next = le;
 
-  return out;
+  le->next = map->tail;
+  map->prev = le;
 }
 
-void grpc_time_channel_key_map_add(grpc_time_channel_key_map* map, double key,
-                                void* value) {
-  size_t count = map->count;
-  size_t capacity = map->capacity;
-  double* keys = map->keys;
-  void** values = map->values;
+void grpc_time_channel_key_map_add(grpc_time_channel_key_map* map,
+                        channel_persistent_le_t le) {
 
-  GPR_ASSERT(count == 0 || keys[count - 1] < key);
-  GPR_ASSERT(value);
-  GPR_ASSERT(grpc_time_channel_key_map_find(map, key) == NULL);
+  le->prev = tail->prev;
+  le->prev->next = le;
 
-  if (count == capacity) {
-    if (map->free > capacity / 4) {
-      count = compact(keys, values, count);
-      map->free = 0;
-    } else {
-      /* resize when less than 25% of the table is free, because compaction
-         won't help much */
-      map->capacity = capacity = 3 * capacity / 2;
-      map->keys = keys = (double*)(
-          gpr_realloc(keys, capacity * sizeof(double)));
-      map->values = values =
-          (void**)(gpr_realloc(values, capacity * sizeof(void*)));
-    }
-  }
+  le->next = map->tail;
+  map->prev = le;
 
-  keys[count] = key;
-  values[count] = value;
-  map->count = count + 1;
+  map->count += 1;
 }
 
-static void** find(grpc_time_channel_key_map* map, double key) {
-  size_t min_idx = 0;
-  size_t max_idx = map->count;
-  size_t mid_idx;
-  double* keys = map->keys;
-  void** values = map->values;
-  double mid_key;
+void* grpc_time_channel_key_map_delete(grpc_time_channel_key_map* map,
+                        channel_persistent_le_t le) {
+  le->prev->next = le->next;
+  le->next->prev = le->prev;
 
-  if (max_idx == 0) return NULL;
+  le->next = map->tail->next;
+  le->next->prev = le;
 
-  while (min_idx < max_idx) {
-    /* find the midpoint, avoiding overflow */
-    mid_idx = min_idx + ((max_idx - min_idx) / 2);
-    mid_key = keys[mid_idx];
+  map->tail->next = le;
+  le->prev = map->tail;
 
-    if (mid_key < key) {
-      min_idx = mid_idx + 1;
-    } else if (mid_key > key) {
-      max_idx = mid_idx;
-    } else /* mid_key == key */
-    {
-      return &values[mid_idx];
-    }
-  }
-
-  return NULL;
+  map->capacity_remain += 1;
 }
 
-void* grpc_time_channel_key_map_delete(grpc_time_channel_key_map* map, double key) {
-  void** pvalue = find(map, key);
-  void* out = NULL;
-  if (pvalue != NULL) {
-    out = *pvalue;
-    *pvalue = NULL;
-    map->free += (out != NULL);
-    /* recognize complete emptyness and ensure we can skip
-     * defragmentation later */
-    if (map->free == map->count) {
-      map->free = map->count = 0;
-    }
-    GPR_ASSERT(grpc_time_channel_key_map_find(map, key) == NULL);
-  }
-  return out;
-}
 
-void* grpc_time_channel_key_map_find(grpc_time_channel_key_map* map, double key) {
-  void** pvalue = find(map, key);
-  return pvalue != NULL ? *pvalue : NULL;
-}
-
-size_t grpc_time_channel_key_map_size(grpc_time_channel_key_map* map) {
-  return map->count - map->free;
-}
-
-void* grpc_time_channel_key_map_rand(grpc_time_channel_key_map* map) {
-  if (map->count == map->free) {
+void* grpc_time_channel_key_map_get_free(grpc_time_channel_key_map* map,
+                        channel_persistent_le_t le) {
+  if(capacity_remain == 0) {
     return NULL;
   }
-  if (map->free != 0) {
-    map->count = compact(map->keys, map->values, map->count);
-    map->free = 0;
-    GPR_ASSERT(map->count > 0);
-  }
-  return map->values[((size_t)(rand())) % map->count];
+  grpc_time_channel_key_map* ret_val = tail->next;
+  tail->next = ret_val->next;
+  return ret_val;
 }
+
+size_t grpc_time_channel_key_map_capacity_remain(grpc_time_channel_key_map* map) {
+  return map->capacity_remain;
+}
+
+
+size_t grpc_time_channel_key_map_size(grpc_time_channel_key_map* map) {
+  return map->count;
+}
+
 
 void grpc_time_channel_key_map_for_each(grpc_time_channel_key_map* map,
                                      void (*f)(void* user_data, double key,
@@ -181,189 +130,3 @@ void grpc_time_channel_key_map_for_each(grpc_time_channel_key_map* map,
     }
   }
 }
-
-
-/*
-#include "map.h"
-
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
-#include <php.h>
-#include <php_ini.h>
-#include <ext/standard/info.h>
-#include <ext/spl/spl_exceptions.h>
-#include "php_grpc.h"
-
-#include <zend_exceptions.h>
-
-#include <stdbool.h>
-
-#include <grpc/grpc.h>
-#include <grpc/support/time.h>
-#include <grpc/support/port_platform.h>
-
-#include <string.h>
-
-#include <grpc/support/alloc.h>
-#include <grpc/support/log.h>
-
-void grpc_time_key_map_init(grpc_time_key_map* map,
-                                 size_t initial_capacity) {
-  GPR_ASSERT(initial_capacity > 1);
-  map->keys =
-      (double*)(pemalloc(sizeof(double) * initial_capacity, true));
-  map->values =
-      (void**)(pemalloc(sizeof(void*) * initial_capacity, true));
-  map->count = 0;
-  map->free = 0;
-  map->capacity = initial_capacity;
-}
-
-void grpc_time_key_map_destroy(grpc_time_key_map* map) {
-  pefree(map->keys, true);
-  pefree(map->values, true);
-}
-
-static size_t compact(double* keys, void** values, size_t count) {
-  size_t i, out;
-
-  for (i = 0, out = 0; i < count; i++) {
-    if (values[i]) {
-      keys[out] = keys[i];
-      values[out] = values[i];
-      out++;
-    }
-  }
-
-  return out;
-}
-
-void grpc_time_key_map_add(grpc_time_key_map* map, double key,
-                                void* value) {
-  size_t count = map->count;
-  size_t capacity = map->capacity;
-  double* keys = map->keys;
-  void** values = map->values;
-
-  GPR_ASSERT(count == 0 || keys[count - 1] < key);
-  GPR_ASSERT(value);
-  GPR_ASSERT(grpc_time_key_map_find(map, key) == NULL);
-
-  if (count == capacity) {
-    if (map->free > capacity / 4) {
-      count = compact(keys, values, count);
-      map->free = 0;
-    } else {
-      map->capacity = capacity = 3 * capacity / 2;
-      map->keys = keys = (double*)(
-          perealloc(keys, capacity * sizeof(double), true));
-      map->values = values =
-          (void**)(perealloc(values, capacity * sizeof(void*), true));
-    }
-  }
-
-  keys[count] = key;
-  values[count] = value;
-  map->count = count + 1;
-}
-
-static void** find(grpc_time_key_map* map, double key) {
-  size_t min_idx = 0;
-  size_t max_idx = map->count;
-  size_t mid_idx;
-  double* keys = map->keys;
-  void** values = map->values;
-  double mid_key;
-
-  if (max_idx == 0) return NULL;
-
-  while (min_idx < max_idx) {
-    mid_idx = min_idx + ((max_idx - min_idx) / 2);
-    mid_key = keys[mid_idx];
-
-    if (mid_key < key) {
-      min_idx = mid_idx + 1;
-    } else if (mid_key > key) {
-      max_idx = mid_idx;
-    } else
-    {
-      return &values[mid_idx];
-    }
-  }
-
-  return NULL;
-}
-
-void* grpc_time_key_map_delete(grpc_time_key_map* map, double key) {
-  void** pvalue = find(map, key);
-  void* out = NULL;
-  if (pvalue != NULL) {
-    out = *pvalue;
-    *pvalue = NULL;
-    map->free += (out != NULL);
-    if (map->free == map->count) {
-      map->free = map->count = 0;
-    }
-    GPR_ASSERT(grpc_time_key_map_find(map, key) == NULL);
-  }
-  return out;
-}
-
-void* grpc_time_key_map_find(grpc_time_key_map* map, double key) {
-  void** pvalue = find(map, key);
-  return pvalue != NULL ? *pvalue : NULL;
-}
-
-void* grpc_time_key_map_top(grpc_time_key_map* map) {
-  if (map->free == map->count) {
-    return NULL;
-  }
-  size_t i, out;
-  for (i = 0, out = 0; i < map->count; i++) {
-    if (map->values[i]) {
-      return map->key[i];
-    }
-  }
-  GPR_ASSERT(i != map->count);
-  return NULL;
-}
-
-void grpc_time_key_map_update(double time_pre, double time_cur, char* key){
-
-}
-//size_t grpc_time_key_map_delete_timeout(grpc_time_key_map* map, size_t index, double timeout, double current_time) {
-//  if (map->free == map->count) {
-//    return NULL;
-//  }
-//  void* value = map->values[index];
-//  if (*value != NULL) {
-//
-//  }
-//  size_t i, out;
-//  for (i = 0, out = 0; i < map->count; i++) {
-//    if (map->map->keys[i] + timeout > current_time) {
-//      return map->values[i];
-//    }
-//  }
-//  return NULL;
-//}
-
-size_t grpc_time_key_map_size(grpc_time_key_map* map) {
-  return map->count - map->free;
-}
-
-void grpc_time_key_map_for_each(grpc_time_key_map* map,
-                                     void (*f)(void* user_data, double key,
-                                               void* value),
-                                     void* user_data) {
-  size_t i;
-
-  for (i = 0; i < map->count; i++) {
-    if (map->values[i]) {
-      f(user_data, map->keys[i], map->values[i]);
-    }
-  }
-}
-*/

--- a/src/php/ext/grpc/map.c
+++ b/src/php/ext/grpc/map.c
@@ -41,50 +41,57 @@
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
 
-void grpc_time_channel_key_map_init(grpc_time_channel_key_map* map,
+void php_grpc_time_key_map_init(php_grpc_time_key_map* map,
                                  size_t initial_capacity) {
   GPR_ASSERT(initial_capacity > 1);
   map->header =
-      (channel_persistent_le_t*)(pemalloc(sizeof(channel_persistent_le_t) * 1));
+      (channel_persistent_le_t*)(pemalloc(sizeof(channel_persistent_le_t) * 1, true));
   map->tail =
-      (channel_persistent_le_t*)(pemalloc(sizeof(channel_persistent_le_t) * 1));
+      (channel_persistent_le_t*)(pemalloc(sizeof(channel_persistent_le_t) * 1, true));
   map->count = 0;
   map->capacity = initial_capacity;
   map->capacity_remain = 0;
 }
 
-void grpc_time_channel_key_map_destroy(grpc_time_channel_key_map* map) {
+void php_grpc_time_key_map_destroy(php_grpc_time_key_map* map) {
   // TODO: free all capacity_remain first
-  gpr_free(map->header);
-  gpr_free(map->tail);
+  channel_persistent_le_t* cur = map->header;
+  channel_persistent_le_t* tmp = NULL;
+  while(cur != map->tail){
+    tmp = cur->next;
+    pefree(cur, true);
+    cur = tmp;
+  }
+  pefree(map->header, true);
+  pefree(map->tail, true);
 }
 
-void grpc_time_key_map_update(grpc_time_channel_key_map* map,
-                        channel_persistent_le_t le) {
+void grpc_time_key_map_update(php_grpc_time_key_map* map,
+                        channel_persistent_le_t* le) {
   le->prev->next = le->next;
   le->next->prev = le->prev;
 
-  le->prev = tail->prev;
+  le->prev = map->tail->prev;
   le->prev->next = le;
 
   le->next = map->tail;
-  map->prev = le;
+  map->tail->prev = le;
 }
 
-void grpc_time_channel_key_map_add(grpc_time_channel_key_map* map,
-                        channel_persistent_le_t le) {
+void php_grpc_time_key_map_add(php_grpc_time_key_map* map,
+                        channel_persistent_le_t* le) {
 
-  le->prev = tail->prev;
+  le->prev = map->tail->prev;
   le->prev->next = le;
 
   le->next = map->tail;
-  map->prev = le;
+  map->tail->prev = le;
 
   map->count += 1;
 }
 
-void* grpc_time_channel_key_map_delete(grpc_time_channel_key_map* map,
-                        channel_persistent_le_t le) {
+void* php_grpc_time_key_map_delete(php_grpc_time_key_map* map,
+                        channel_persistent_le_t* le) {
   le->prev->next = le->next;
   le->next->prev = le->prev;
 
@@ -95,38 +102,43 @@ void* grpc_time_channel_key_map_delete(grpc_time_channel_key_map* map,
   le->prev = map->tail;
 
   map->capacity_remain += 1;
+  return le;
 }
 
 
-void* grpc_time_channel_key_map_get_free(grpc_time_channel_key_map* map,
-                        channel_persistent_le_t le) {
-  if(capacity_remain == 0) {
+void* php_grpc_time_key_map_get_free(php_grpc_time_key_map* map,
+                        channel_persistent_le_t* le) {
+  if(map->capacity_remain == 0) {
     return NULL;
   }
-  grpc_time_channel_key_map* ret_val = tail->next;
-  tail->next = ret_val->next;
+  channel_persistent_le_t* ret_val = map->tail->next;
+  map->tail->next = ret_val->next;
   return ret_val;
 }
 
-size_t grpc_time_channel_key_map_capacity_remain(grpc_time_channel_key_map* map) {
+size_t php_grpc_time_key_map_capacity_remain(php_grpc_time_key_map* map) {
   return map->capacity_remain;
 }
 
 
-size_t grpc_time_channel_key_map_size(grpc_time_channel_key_map* map) {
+size_t php_grpc_time_key_map_size(php_grpc_time_key_map* map) {
   return map->count;
 }
 
+void* grpc_time_key_map_get_top(php_grpc_time_key_map* map) {
+  return map->header->next;
+}
 
-void grpc_time_channel_key_map_for_each(grpc_time_channel_key_map* map,
+
+void php_grpc_time_key_map_for_each(php_grpc_time_key_map* map,
                                      void (*f)(void* user_data, double key,
                                                void* value),
                                      void* user_data) {
-  size_t i;
-
-  for (i = 0; i < map->count; i++) {
-    if (map->values[i]) {
-      f(user_data, map->keys[i], map->values[i]);
-    }
-  }
+//  size_t i;
+//
+//  for (i = 0; i < map->count; i++) {
+//    if (map->values[i]) {
+//      f(user_data, map->keys[i], map->values[i]);
+//    }
+//  }
 }

--- a/src/php/ext/grpc/map.c
+++ b/src/php/ext/grpc/map.c
@@ -118,6 +118,8 @@ void* php_grpc_time_key_map_delete(php_grpc_time_key_map* map,
   map->tail->next = le;
   le->prev = map->tail;
 
+  le->ref_count = 0;
+
 //  map->capacity_remain += 1;
   map->count -= 1;
   php_printf("php_grpc_time_key_map_delete end\n");

--- a/src/php/ext/grpc/map.h
+++ b/src/php/ext/grpc/map.h
@@ -42,19 +42,11 @@
    Adds are restricted to strictly higher keys than previously seen (this is
    guaranteed by http2). */
 typedef struct {
-//  double* keys;
-//  void** values;
-  size_t count;
-  size_t capacity;
+  size_t* count;
   channel_persistent_le_t* header;
   channel_persistent_le_t* tail;
 } php_grpc_time_key_map;
 
-
-//struct pair_time_channel {
-//    size_t timestamp;
-//    char* channel_key;
-//};
 
 void php_grpc_time_key_map_init(php_grpc_time_key_map* map,
                                  size_t initial_capacity);

--- a/src/php/ext/grpc/map.h
+++ b/src/php/ext/grpc/map.h
@@ -1,0 +1,86 @@
+/*
+ *
+ * Copyright 2015 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef NET_GRPC_PHP_GRPC_MAP_H_
+#define NET_GRPC_PHP_GRPC_MAP_H_
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <php.h>
+#include <php_ini.h>
+#include <ext/standard/info.h>
+#include "php_grpc.h"
+#include "channel.h"
+
+#include <grpc/grpc.h>
+#include <grpc/support/time.h>
+
+#include <grpc/support/port_platform.h>
+
+#include <stddef.h>
+
+/* Data structure to map a double to a data object (represented by a void*)
+   Represented as a sorted array of keys, and a corresponding array of values.
+   Lookups are performed with binary search.
+   Adds are restricted to strictly higher keys than previously seen (this is
+   guaranteed by http2). */
+typedef struct {
+  double* keys;
+  void** values;
+  size_t count;
+  size_t free;
+  size_t capacity;
+} grpc_time_channel_key_map;
+
+
+//struct pair_time_channel {
+//    size_t timestamp;
+//    char* channel_key;
+//};
+
+void grpc_time_channel_key_map_init(grpc_time_channel_key_map* map,
+                                 size_t initial_capacity);
+void grpc_time_channel_key_map_destroy(grpc_time_channel_key_map* map);
+
+/* Add a new key: given http2 semantics, new keys must always be greater than
+   existing keys - this is asserted */
+void grpc_time_channel_key_map_add(grpc_time_channel_key_map* map, double key,
+                                void* value);
+
+/* Delete an existing key - returns the previous value of the key if it existed,
+   or NULL otherwise */
+void* grpc_time_channel_key_map_delete(grpc_time_channel_key_map* map, double key);
+
+/* Return an existing key, or NULL if it does not exist */
+void* grpc_time_channel_key_map_find(grpc_time_channel_key_map* map, double key);
+
+/* Return a random entry */
+void* grpc_time_channel_key_map_rand(grpc_time_channel_key_map* map);
+
+/* How many (populated) entries are in the stream map? */
+size_t grpc_time_channel_key_map_size(grpc_time_channel_key_map* map);
+
+/* Callback on each stream */
+void grpc_time_channel_key_map_for_each(grpc_time_channel_key_map* map,
+                                     void (*f)(void* user_data, double key,
+                                               void* value),
+                                     void* user_data);
+
+#endif /* GRPC_CORE_EXT_TRANSPORT_CHTTP2_TRANSPORT_STREAM_MAP_H */

--- a/src/php/ext/grpc/map.h
+++ b/src/php/ext/grpc/map.h
@@ -46,7 +46,6 @@ typedef struct {
 //  void** values;
   size_t count;
   size_t capacity;
-  size_t capacity_remain; // When a channel is deleted, the memory won't be freed. When the next channel is created, reuse it.
   channel_persistent_le_t* header;
   channel_persistent_le_t* tail;
 } php_grpc_time_key_map;
@@ -63,12 +62,12 @@ void php_grpc_time_key_map_destroy(php_grpc_time_key_map* map);
 
 /* Add a new key: given http2 semantics, new keys must always be greater than
    existing keys - this is asserted */
-void grpc_time_key_map_update(php_grpc_time_key_map* map,
+void php_grpc_time_key_map_update(php_grpc_time_key_map* map,
                         channel_persistent_le_t* le);
 
 /* Delete an existing key - returns the previous value of the key if it existed,
    or NULL otherwise */
-void php_grpc_time_key_map_add(php_grpc_time_key_map* map,
+void php_grpc_time_key_map_append(php_grpc_time_key_map* map,
                         channel_persistent_le_t* le);
 
 /* Return an existing key, or NULL if it does not exist */
@@ -78,9 +77,6 @@ void* php_grpc_time_key_map_delete(php_grpc_time_key_map* map,
 /* Return a random entry */
 void* php_grpc_time_key_map_get_free(php_grpc_time_key_map* map,
                         channel_persistent_le_t* le);
-
-/* How many (populated) entries are in the stream map? */
-size_t php_grpc_time_key_map_capacity_remain(php_grpc_time_key_map* map);
 
 /* Callback on each stream */
 size_t php_grpc_time_key_map_size(php_grpc_time_key_map* map);
@@ -92,5 +88,6 @@ void php_grpc_time_key_map_print(php_grpc_time_key_map* map);
 // only for test
 void php_grpc_time_key_map_re_init_test(php_grpc_time_key_map* map);
 
+void* grpc_time_key_map_get_first_free(php_grpc_time_key_map* map);
 
 #endif /* GRPC_CORE_EXT_TRANSPORT_CHTTP2_TRANSPORT_STREAM_MAP_H */

--- a/src/php/ext/grpc/map.h
+++ b/src/php/ext/grpc/map.h
@@ -36,17 +36,19 @@
 
 #include <stddef.h>
 
-/* Data structure to map a double to a data object (represented by a void*)
-   Represented as a sorted array of keys, and a corresponding array of values.
+/* Data structure to queueueueueueue
+   Represented as a sorted queueueueue of keys, and a corresponding array of values.
    Lookups are performed with binary search.
    Adds are restricted to strictly higher keys than previously seen (this is
    guaranteed by http2). */
 typedef struct {
-  double* keys;
-  void** values;
+//  double* keys;
+//  void** values;
   size_t count;
-  size_t free;
   size_t capacity;
+  size_t capacity_remain; // When a channel is deleted, the memory won't be freed. When the next channel is created, reuse it.
+  channel_persistent_le_t* header;
+  channel_persistent_le_t* tail;
 } grpc_time_channel_key_map;
 
 

--- a/src/php/ext/grpc/map.h
+++ b/src/php/ext/grpc/map.h
@@ -49,7 +49,7 @@ typedef struct {
   size_t capacity_remain; // When a channel is deleted, the memory won't be freed. When the next channel is created, reuse it.
   channel_persistent_le_t* header;
   channel_persistent_le_t* tail;
-} grpc_time_channel_key_map;
+} php_grpc_time_key_map;
 
 
 //struct pair_time_channel {
@@ -57,32 +57,34 @@ typedef struct {
 //    char* channel_key;
 //};
 
-void grpc_time_channel_key_map_init(grpc_time_channel_key_map* map,
+void php_grpc_time_key_map_init(php_grpc_time_key_map* map,
                                  size_t initial_capacity);
-void grpc_time_channel_key_map_destroy(grpc_time_channel_key_map* map);
+void php_grpc_time_key_map_destroy(php_grpc_time_key_map* map);
 
 /* Add a new key: given http2 semantics, new keys must always be greater than
    existing keys - this is asserted */
-void grpc_time_channel_key_map_add(grpc_time_channel_key_map* map, double key,
-                                void* value);
+void grpc_time_key_map_update(php_grpc_time_key_map* map,
+                        channel_persistent_le_t* le);
 
 /* Delete an existing key - returns the previous value of the key if it existed,
    or NULL otherwise */
-void* grpc_time_channel_key_map_delete(grpc_time_channel_key_map* map, double key);
+void php_grpc_time_key_map_add(php_grpc_time_key_map* map,
+                        channel_persistent_le_t* le);
 
 /* Return an existing key, or NULL if it does not exist */
-void* grpc_time_channel_key_map_find(grpc_time_channel_key_map* map, double key);
+void* php_grpc_time_key_map_delete(php_grpc_time_key_map* map,
+                        channel_persistent_le_t* le);
 
 /* Return a random entry */
-void* grpc_time_channel_key_map_rand(grpc_time_channel_key_map* map);
+void* php_grpc_time_key_map_get_free(php_grpc_time_key_map* map,
+                        channel_persistent_le_t* le);
 
 /* How many (populated) entries are in the stream map? */
-size_t grpc_time_channel_key_map_size(grpc_time_channel_key_map* map);
+size_t php_grpc_time_key_map_capacity_remain(php_grpc_time_key_map* map);
 
 /* Callback on each stream */
-void grpc_time_channel_key_map_for_each(grpc_time_channel_key_map* map,
-                                     void (*f)(void* user_data, double key,
-                                               void* value),
-                                     void* user_data);
+size_t php_grpc_time_key_map_size(php_grpc_time_key_map* map);
+
+void* grpc_time_key_map_get_top(php_grpc_time_key_map* map);
 
 #endif /* GRPC_CORE_EXT_TRANSPORT_CHTTP2_TRANSPORT_STREAM_MAP_H */

--- a/src/php/ext/grpc/map.h
+++ b/src/php/ext/grpc/map.h
@@ -89,4 +89,8 @@ void* grpc_time_key_map_get_top(php_grpc_time_key_map* map);
 
 void php_grpc_time_key_map_print(php_grpc_time_key_map* map);
 
+// only for test
+void php_grpc_time_key_map_re_init_test(php_grpc_time_key_map* map);
+
+
 #endif /* GRPC_CORE_EXT_TRANSPORT_CHTTP2_TRANSPORT_STREAM_MAP_H */

--- a/src/php/ext/grpc/map.h
+++ b/src/php/ext/grpc/map.h
@@ -87,4 +87,6 @@ size_t php_grpc_time_key_map_size(php_grpc_time_key_map* map);
 
 void* grpc_time_key_map_get_top(php_grpc_time_key_map* map);
 
+void php_grpc_time_key_map_print(php_grpc_time_key_map* map);
+
 #endif /* GRPC_CORE_EXT_TRANSPORT_CHTTP2_TRANSPORT_STREAM_MAP_H */

--- a/src/php/ext/grpc/map.h
+++ b/src/php/ext/grpc/map.h
@@ -80,6 +80,6 @@ void php_grpc_time_key_map_print(php_grpc_time_key_map* map);
 // only for test
 void php_grpc_time_key_map_re_init_test(php_grpc_time_key_map* map);
 
-void* grpc_time_key_map_get_first_free(php_grpc_time_key_map* map);
+void* grpc_time_key_map_get_first_free(php_grpc_time_key_map* map, gpr_timespec time_cur, int32_t timeout);
 
 #endif /* GRPC_CORE_EXT_TRANSPORT_CHTTP2_TRANSPORT_STREAM_MAP_H */

--- a/src/php/ext/grpc/php_grpc.c
+++ b/src/php/ext/grpc/php_grpc.c
@@ -232,6 +232,7 @@ PHP_MINIT_FUNCTION(grpc) {
   grpc_init_channel_credentials(TSRMLS_C);
   grpc_init_call_credentials(TSRMLS_C);
   grpc_init_server_credentials(TSRMLS_C);
+  php_printf("PHP_MINIT_FUNCTION ends\n");
   return SUCCESS;
 }
 /* }}} */

--- a/src/php/ext/grpc/php_grpc.c
+++ b/src/php/ext/grpc/php_grpc.c
@@ -18,6 +18,7 @@
 
 #include "call.h"
 #include "channel.h"
+#include "map.h"
 #include "server.h"
 #include "timeval.h"
 #include "channel_credentials.h"
@@ -101,7 +102,8 @@ PHP_MINIT_FUNCTION(grpc) {
   /* If you have INI entries, uncomment these lines
      REGISTER_INI_ENTRIES();
   */
-  grpc_time_key_map_init(&channel_register, 20);
+  size_t persisten_channel_upper_bound = 20;
+  php_grpc_time_key_map_init(&channel_register, persisten_channel_upper_bound);
   /* Register call error constants */
   REGISTER_LONG_CONSTANT("Grpc\\CALL_OK", GRPC_CALL_OK,
                          CONST_CS | CONST_PERSISTENT);

--- a/src/php/ext/grpc/php_grpc.c
+++ b/src/php/ext/grpc/php_grpc.c
@@ -39,7 +39,8 @@ ZEND_DECLARE_MODULE_GLOBALS(grpc)
 static PHP_GINIT_FUNCTION(grpc);
 
 php_grpc_time_key_map channel_register;
-
+int32_t* persistent_channel_timeout;
+size_t* persisten_channel_upper_bound;
 /* {{{ grpc_functions[]
  *
  * Every user visible function must have an entry in grpc_functions[].
@@ -102,8 +103,17 @@ PHP_MINIT_FUNCTION(grpc) {
   /* If you have INI entries, uncomment these lines
      REGISTER_INI_ENTRIES();
   */
-  size_t persisten_channel_upper_bound = 20;
-  php_grpc_time_key_map_init(&channel_register, persisten_channel_upper_bound);
+//  size_t persisten_channel_upper_bound = 20;
+
+  persistent_channel_timeout =
+        (int32_t*)(pemalloc(sizeof(int32_t) * 1, true));
+  persisten_channel_upper_bound =
+        (size_t*)(pemalloc(sizeof(size_t) * 1, true));
+  // default timeout equals 30ms.
+  *persistent_channel_timeout = 30;
+  *persisten_channel_upper_bound = 3;
+
+  php_grpc_time_key_map_init(&channel_register, *persisten_channel_upper_bound);
   /* Register call error constants */
   REGISTER_LONG_CONSTANT("Grpc\\CALL_OK", GRPC_CALL_OK,
                          CONST_CS | CONST_PERSISTENT);

--- a/src/php/ext/grpc/php_grpc.c
+++ b/src/php/ext/grpc/php_grpc.c
@@ -37,6 +37,8 @@
 ZEND_DECLARE_MODULE_GLOBALS(grpc)
 static PHP_GINIT_FUNCTION(grpc);
 
+php_grpc_time_key_map channel_register;
+
 /* {{{ grpc_functions[]
  *
  * Every user visible function must have an entry in grpc_functions[].
@@ -99,6 +101,7 @@ PHP_MINIT_FUNCTION(grpc) {
   /* If you have INI entries, uncomment these lines
      REGISTER_INI_ENTRIES();
   */
+  grpc_time_key_map_init(&channel_register, 20);
   /* Register call error constants */
   REGISTER_LONG_CONSTANT("Grpc\\CALL_OK", GRPC_CALL_OK,
                          CONST_CS | CONST_PERSISTENT);

--- a/src/php/tests/unit_tests/CallTest.php
+++ b/src/php/tests/unit_tests/CallTest.php
@@ -38,6 +38,9 @@ class CallTest extends PHPUnit_Framework_TestCase
     public function tearDown()
     {
         $this->channel->close();
+        $channel_destory_persistent =
+          new Grpc\Channel('localhost:01010', []);
+        $channel_destory_persistent->destoryPersistentList();
     }
 
     public function testConstructor()

--- a/src/php/tests/unit_tests/ChannelTest.php
+++ b/src/php/tests/unit_tests/ChannelTest.php
@@ -423,6 +423,7 @@ class ChannelTest extends PHPUnit_Framework_TestCase
 
     public function callbackFunc($context)
     {
+      php_printf("call_back_fund\n");
         return [];
     }
 
@@ -444,7 +445,7 @@ class ChannelTest extends PHPUnit_Framework_TestCase
         // always be created new and NOT persisted.
         $this->channel1 = new Grpc\Channel('localhost:1',
                                            ["credentials" =>
-                                            $credsWithCallCreds]);
+                                             $credsWithCallCreds]);
         $this->channel2 = new Grpc\Channel('localhost:1',
                                            ["credentials" =>
                                             $credsWithCallCreds]);
@@ -530,7 +531,6 @@ class ChannelTest extends PHPUnit_Framework_TestCase
         $this->channel2 = new Grpc\Channel('localhost:1',
                                            ["force_new" => true]);
         // channel3 shares with channel1
-        usleep(500 * 1000);
         $this->channel3 = new Grpc\Channel('localhost:1', []);
 
         // try to connect on channel2
@@ -568,27 +568,27 @@ class ChannelTest extends PHPUnit_Framework_TestCase
 //        // channel3 already closed
 //        $state = $this->channel3->getConnectivityState();
 //    }
-//
-//    public function testPersistentChannelForceNewNewChannelClose()
-//    {
-//
-//        $this->channel1 = new Grpc\Channel('localhost:1', []);
-//        $this->channel2 = new Grpc\Channel('localhost:1',
-//                                           ["force_new" => true]);
-//        $this->channel3 = new Grpc\Channel('localhost:1', []);
-//
-//        $this->channel2->close();
-//
-//        $state = $this->channel1->getConnectivityState();
-//        $this->assertEquals(GRPC\CHANNEL_IDLE, $state);
-//
-//        // can still connect on channel1
-//        $state = $this->channel1->getConnectivityState(true);
-//        $this->waitUntilNotIdle($this->channel1);
-//
-//        $state = $this->channel1->getConnectivityState();
-//        $this->assertConnecting($state);
-//
-//        $this->channel1->close();
-//    }
+
+    public function testPersistentChannelForceNewNewChannelClose()
+    {
+
+        $this->channel1 = new Grpc\Channel('localhost:1', []);
+        $this->channel2 = new Grpc\Channel('localhost:1',
+                                           ["force_new" => true]);
+        $this->channel3 = new Grpc\Channel('localhost:1', []);
+
+        $this->channel2->close();
+
+        $state = $this->channel1->getConnectivityState();
+        $this->assertEquals(GRPC\CHANNEL_IDLE, $state);
+
+        // can still connect on channel1
+        $state = $this->channel1->getConnectivityState(true);
+        $this->waitUntilNotIdle($this->channel1);
+
+        $state = $this->channel1->getConnectivityState();
+        $this->assertConnecting($state);
+
+        $this->channel1->close();
+    }
 }

--- a/src/php/tests/unit_tests/ChannelTest.php
+++ b/src/php/tests/unit_tests/ChannelTest.php
@@ -28,6 +28,9 @@ class ChannelTest extends PHPUnit_Framework_TestCase
         if (!empty($this->channel)) {
             $this->channel->close();
         }
+        if (!empty($this->channel1)) {
+          $this->channel1->destoryPersistentList();
+        }
     }
 
     public function testInsecureCredentials()
@@ -368,21 +371,21 @@ class ChannelTest extends PHPUnit_Framework_TestCase
         $this->channel2->close();
     }
 
-    /**
-     * @expectedException RuntimeException
-     */
-    public function testPersistentChannelSharedChannelClose()
-    {
-        // same underlying channel
-        $this->channel1 = new Grpc\Channel('localhost:1', []);
-        $this->channel2 = new Grpc\Channel('localhost:1', []);
-
-        // close channel1
-        $this->channel1->close();
-
-        // channel is already closed
-        $state = $this->channel2->getConnectivityState();
-    }
+//    /**
+//     * @expectedException RuntimeException
+//     */
+//    public function testPersistentChannelSharedChannelClose()
+//    {
+//        // same underlying channel
+//        $this->channel1 = new Grpc\Channel('localhost:1', []);
+//        $this->channel2 = new Grpc\Channel('localhost:1', []);
+//
+//        // close channel1
+//        $this->channel1->close();
+//
+//        // channel is already closed
+//        $state = $this->channel2->getConnectivityState();
+//    }
 
     public function testPersistentChannelCreateAfterClose()
     {
@@ -527,6 +530,7 @@ class ChannelTest extends PHPUnit_Framework_TestCase
         $this->channel2 = new Grpc\Channel('localhost:1',
                                            ["force_new" => true]);
         // channel3 shares with channel1
+        usleep(500 * 1000);
         $this->channel3 = new Grpc\Channel('localhost:1', []);
 
         // try to connect on channel2
@@ -544,47 +548,47 @@ class ChannelTest extends PHPUnit_Framework_TestCase
         $this->channel2->close();
     }
 
-    /**
-     * @expectedException RuntimeException
-     */
-    public function testPersistentChannelForceNewOldChannelClose()
-    {
-
-        $this->channel1 = new Grpc\Channel('localhost:1', []);
-        $this->channel2 = new Grpc\Channel('localhost:1',
-                                           ["force_new" => true]);
-        // channel3 shares with channel1
-        $this->channel3 = new Grpc\Channel('localhost:1', []);
-
-        $this->channel1->close();
-
-        $state = $this->channel2->getConnectivityState();
-        $this->assertEquals(GRPC\CHANNEL_IDLE, $state);
-
-        // channel3 already closed
-        $state = $this->channel3->getConnectivityState();
-    }
-
-    public function testPersistentChannelForceNewNewChannelClose()
-    {
-
-        $this->channel1 = new Grpc\Channel('localhost:1', []);
-        $this->channel2 = new Grpc\Channel('localhost:1',
-                                           ["force_new" => true]);
-        $this->channel3 = new Grpc\Channel('localhost:1', []);
-
-        $this->channel2->close();
-
-        $state = $this->channel1->getConnectivityState();
-        $this->assertEquals(GRPC\CHANNEL_IDLE, $state);
-
-        // can still connect on channel1
-        $state = $this->channel1->getConnectivityState(true);
-        $this->waitUntilNotIdle($this->channel1);
-
-        $state = $this->channel1->getConnectivityState();
-        $this->assertConnecting($state);
-
-        $this->channel1->close();
-    }
+//    /**
+//     * @expectedException RuntimeException
+//     */
+//    public function testPersistentChannelForceNewOldChannelClose()
+//    {
+//
+//        $this->channel1 = new Grpc\Channel('localhost:1', []);
+//        $this->channel2 = new Grpc\Channel('localhost:1',
+//                                           ["force_new" => true]);
+//        // channel3 shares with channel1
+//        $this->channel3 = new Grpc\Channel('localhost:1', []);
+//
+//        $this->channel1->close();
+//
+//        $state = $this->channel2->getConnectivityState();
+//        $this->assertEquals(GRPC\CHANNEL_IDLE, $state);
+//
+//        // channel3 already closed
+//        $state = $this->channel3->getConnectivityState();
+//    }
+//
+//    public function testPersistentChannelForceNewNewChannelClose()
+//    {
+//
+//        $this->channel1 = new Grpc\Channel('localhost:1', []);
+//        $this->channel2 = new Grpc\Channel('localhost:1',
+//                                           ["force_new" => true]);
+//        $this->channel3 = new Grpc\Channel('localhost:1', []);
+//
+//        $this->channel2->close();
+//
+//        $state = $this->channel1->getConnectivityState();
+//        $this->assertEquals(GRPC\CHANNEL_IDLE, $state);
+//
+//        // can still connect on channel1
+//        $state = $this->channel1->getConnectivityState(true);
+//        $this->waitUntilNotIdle($this->channel1);
+//
+//        $state = $this->channel1->getConnectivityState();
+//        $this->assertConnecting($state);
+//
+//        $this->channel1->close();
+//    }
 }

--- a/src/php/tests/unit_tests/ChannelTest.php
+++ b/src/php/tests/unit_tests/ChannelTest.php
@@ -28,9 +28,9 @@ class ChannelTest extends PHPUnit_Framework_TestCase
         if (!empty($this->channel)) {
             $this->channel->close();
         }
-        if (!empty($this->channel1)) {
-          $this->channel1->destoryPersistentList();
-        }
+        $channel_destory_persistent =
+          new Grpc\Channel('localhost:01010', []);
+        $channel_destory_persistent->destoryPersistentList();
     }
 
     public function testInsecureCredentials()

--- a/src/php/tests/unit_tests/ChannelTest.php
+++ b/src/php/tests/unit_tests/ChannelTest.php
@@ -30,7 +30,9 @@ class ChannelTest extends PHPUnit_Framework_TestCase
         }
         $channel_destory_persistent =
           new Grpc\Channel('localhost:01010', []);
-        $channel_destory_persistent->destoryPersistentList();
+      $channel_destory_persistent->destoryPersistentList();
+      $channel_destory_persistent->printPersistentList();
+      $channel_destory_persistent->initPersistentList();
     }
 
     public function testInsecureCredentials()

--- a/src/php/tests/unit_tests/EndToEndTest.php
+++ b/src/php/tests/unit_tests/EndToEndTest.php
@@ -29,6 +29,9 @@ class EndToEndTest extends PHPUnit_Framework_TestCase
     public function tearDown()
     {
         $this->channel->close();
+        $channel_destory_persistent =
+          new Grpc\Channel('localhost:01010', []);
+        $channel_destory_persistent->destoryPersistentList();
     }
 
     public function testSimpleRequestBody()

--- a/src/php/tests/unit_tests/EndToEndTest.php
+++ b/src/php/tests/unit_tests/EndToEndTest.php
@@ -32,6 +32,8 @@ class EndToEndTest extends PHPUnit_Framework_TestCase
         $channel_destory_persistent =
           new Grpc\Channel('localhost:01010', []);
         $channel_destory_persistent->destoryPersistentList();
+        $channel_destory_persistent->printPersistentList();
+        $channel_destory_persistent->initPersistentList();
     }
 
     public function testSimpleRequestBody()

--- a/src/php/tests/unit_tests/PersistentListTest.php
+++ b/src/php/tests/unit_tests/PersistentListTest.php
@@ -1,0 +1,106 @@
+<?php
+/*
+ *
+ * Copyright 2015 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+class PersistentListTest extends PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+    }
+
+    public function tearDown()
+    {
+
+        $channel_destory_persistent =
+          new Grpc\Channel('localhost:01010', []);
+        $channel_destory_persistent->destoryPersistentList();
+        $channel_destory_persistent->printPersistentList();
+        $channel_destory_persistent->initPersistentList();
+    }
+
+
+    public function testPersistentChannelSameHost()
+    {
+        $this->channel1 = new Grpc\Channel('localhost:1', []);
+        // the underlying grpc channel is the same by default
+        // when connecting to the same host
+        $this->channel2 = new Grpc\Channel('localhost:1', []);
+
+        //ref_count should be 2
+        $this->channel1->printPersistentList();
+
+        $this->channel1->close();
+        //ref_count should be 1
+        $this->channel1->printPersistentList();
+
+        $this->channel2->close();
+        //ref_count should be 0
+        $this->channel1->printPersistentList();
+    }
+
+    public function testPersistentChannelDifferentHost()
+    {
+        // two different underlying channels because different hostname
+        $this->channel1 = new Grpc\Channel('localhost:1', []);
+        $this->channel2 = new Grpc\Channel('localhost:2', []);
+
+        $this->channel1->printPersistentList();
+
+        $this->channel1->close();
+        $this->channel2->close();
+    }
+
+
+    public function testPersistentChannelTimeout()
+    {
+      // the default timeout is 30ms.
+      $this->channel1 = new Grpc\Channel('localhost:1', []);
+      $this->channel1->printPersistentList();
+      usleep(15*1000);
+      $this->channel2 = new Grpc\Channel('localhost:2', []);
+      $this->channel1->printPersistentList();
+      usleep(31*1000);
+      $this->channel3 = new Grpc\Channel('localhost:3', []);
+      echo "channel1 and channel2 should be expiredddddddddddddddddd-------------\n";
+      $this->channel1->printPersistentList();
+
+      $this->channel1->close();
+      $this->channel2->close();
+      $this->channel3->close();
+    }
+
+    public function testPersistentChannelOutbound()
+    {
+      // the default size is 3
+      $this->channel1 = new Grpc\Channel('localhost:1', []);
+      $this->channel1->printPersistentList();
+      $this->channel2 = new Grpc\Channel('localhost:2', []);
+      $this->channel1->printPersistentList();
+      $this->channel3 = new Grpc\Channel('localhost:3', []);
+      $this->channel1->printPersistentList();
+      $this->channel4 = new Grpc\Channel('localhost:4', []);
+      $this->channel1->printPersistentList();
+
+      $this->channel1->close();
+      $this->channel2->close();
+      $this->channel3->close();
+      $this->channel4->close();
+      //$this->channel1->printPersistentList();
+    }
+
+}

--- a/src/php/tests/unit_tests/PersistentListTest.php
+++ b/src/php/tests/unit_tests/PersistentListTest.php
@@ -28,9 +28,9 @@ class PersistentListTest extends PHPUnit_Framework_TestCase
 
         $channel_destory_persistent =
           new Grpc\Channel('localhost:01010', []);
-//        $channel_destory_persistent->destoryPersistentList();
-//        $channel_destory_persistent->printPersistentList();
-//        $channel_destory_persistent->initPersistentList();
+        $channel_destory_persistent->destoryPersistentList();
+        $channel_destory_persistent->printPersistentList();
+        $channel_destory_persistent->initPersistentList();
     }
 
 
@@ -71,16 +71,15 @@ class PersistentListTest extends PHPUnit_Framework_TestCase
       // the default timeout is 30ms.
       $this->channel1 = new Grpc\Channel('localhost:1', []);
       $this->channel1->printPersistentList();
+      $this->channel1->close();
       usleep(15*1000);
       $this->channel2 = new Grpc\Channel('localhost:2', []);
       $this->channel1->printPersistentList();
+      $this->channel2->close();
       usleep(31*1000);
       $this->channel3 = new Grpc\Channel('localhost:3', []);
       echo "channel1 and channel2 should be expiredddddddddddddddddd-------------\n";
       $this->channel1->printPersistentList();
-
-      $this->channel1->close();
-      $this->channel2->close();
       $this->channel3->close();
     }
 

--- a/src/php/tests/unit_tests/PersistentListTest.php
+++ b/src/php/tests/unit_tests/PersistentListTest.php
@@ -28,9 +28,9 @@ class PersistentListTest extends PHPUnit_Framework_TestCase
 
         $channel_destory_persistent =
           new Grpc\Channel('localhost:01010', []);
-        $channel_destory_persistent->destoryPersistentList();
-        $channel_destory_persistent->printPersistentList();
-        $channel_destory_persistent->initPersistentList();
+//        $channel_destory_persistent->destoryPersistentList();
+//        $channel_destory_persistent->printPersistentList();
+//        $channel_destory_persistent->initPersistentList();
     }
 
 

--- a/src/php/tests/unit_tests/ServerTest.php
+++ b/src/php/tests/unit_tests/ServerTest.php
@@ -27,6 +27,9 @@ class ServerTest extends PHPUnit_Framework_TestCase
     public function tearDown()
     {
         unset($this->server);
+        $channel_destory_persistent =
+            new Grpc\Channel('localhost:01010', []);
+        $channel_destory_persistent->destoryPersistentList();
     }
 
     public function testConstructorWithNull()

--- a/src/php/tests/unit_tests/ServerTest.php
+++ b/src/php/tests/unit_tests/ServerTest.php
@@ -30,6 +30,8 @@ class ServerTest extends PHPUnit_Framework_TestCase
         $channel_destory_persistent =
             new Grpc\Channel('localhost:01010', []);
         $channel_destory_persistent->destoryPersistentList();
+        $channel_destory_persistent->printPersistentList();
+        $channel_destory_persistent->initPersistentList();
     }
 
     public function testConstructorWithNull()


### PR DESCRIPTION
This pr is a draft.

The idea is still use the current persistent list, while keeping an order by making each channel a node in the linked list.  
- Add a timeval into the channel.
- The order of linked list is easy to maintain because new channel/updated channel always have the biggest timeval, and just append to the end of the linked list.
- Keep the allocation for deleted channel(put it after the tail) so next time when a new channel is created, it can reuse the allocation.
- Deleting the channel `if ref_count>0 && timeout`