### PR TITLE
GCP extension via interceptor

### DIFF
--- a/src/php/lib/Grpc/GCP_extension/.gitignore
+++ b/src/php/lib/Grpc/GCP_extension/.gitignore
@@ -1,0 +1,1 @@
+tests/generated

--- a/src/php/lib/Grpc/GCP_extension/src/ChannelRef.php
+++ b/src/php/lib/Grpc/GCP_extension/src/ChannelRef.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Grpc_gcp;
+
+class _ChannelRef
+{
+  // It has all information except Credentials for creating a Grpc\Channel.
+  // It is used in getRealChannel method.
+  private $opts;
+
+  private $channel_id;
+  private $affinity_ref;
+  private $active_stream_ref;
+  private $target;
+
+  public function __construct($target, $channel_id, $opts, $affinity_ref=0, $active_stream_ref=0)
+  {
+    $this->target = $target;
+    $this->channel_id = $channel_id;
+    $this->affinity_ref = $affinity_ref;
+    $this->active_stream_ref = $active_stream_ref;
+    $this->opts = $opts;
+  }
+
+  public function getRealChannel($credentials) {
+    // 'credentials' in the array $opts will be unset during creating the channel.
+    if(!array_key_exists('credentials', $this->opts)){
+      $this->opts['credentials'] = $credentials;
+    }
+    // TODO(ddyihai): if not running the script in the PHP-FPM mode, we don't need to
+    // The only reason for recreating the Grpc\Channel everytime is that Grpc\Channel don't
+    // have serialize and deserialize handler. When we fetching the $gcp_channel from the
+    // pool, all Grpc\Channel objects are point to an random location which leads to segment
+    // fault.
+    // Since [target + augments + credentials] will reuse the underline grpc channel in C extension
+    // if exists, recreating a PHP object doesn't do too much harm because it only link the
+    // \Grpc\Channel to a pointer in underline grpc channel without creating any extra things.
+    $real_channel = new \Grpc\Channel($this->target, $this->opts);
+    return $real_channel;
+  }
+
+  public function getAffinityRef() {return $this->affinity_ref;}
+  public function getActiveStreamRef() {return $this->active_stream_ref;}
+  public function affinityRefIncr() {$this->affinity_ref += 1;}
+  public function affinityRefDecr() {$this->affinity_ref -= 1;}
+  public function activeStreamRefIncr() {$this->active_stream_ref += 1;}
+  public function activeStreamRefDecr() {$this->active_stream_ref -= 1;}
+}

--- a/src/php/lib/Grpc/GCP_extension/src/EnableGCP.php
+++ b/src/php/lib/Grpc/GCP_extension/src/EnableGCP.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Grpc_gcp;
+
+use Google\Auth\ApplicationDefaultCredentials;
+
+function parseConfObject($conf_object) {
+  $config = json_decode($conf_object->serializeToJsonString(), true);
+  $api_conf = $config['api'][0];
+  $global_conf['target'] = $api_conf['target'];
+  $global_conf['channelPool'] = $api_conf['channelPool'];
+  $aff_by_method = array();
+  for ($i = 0; $i < count($api_conf['method']); $i++) {
+    // In proto3, if the value is default, eg 0 for int, it won't be serialized.
+    // Thus serialized string may not have `command` if the value is default 0(BOUND).
+    if (!array_key_exists('command', $api_conf['method'][$i]['affinity'])) {
+      $api_conf['method'][$i]['affinity']['command'] = 'BOUND';
+    }
+    $aff_by_method[$api_conf['method'][$i]['name'][0]] = $api_conf['method'][$i]['affinity'];
+  }
+  $global_conf['affinity_by_method'] = $aff_by_method;
+  return $global_conf;
+}
+
+function enableGrpcGcp($conf, $opts) {
+
+  $channel_pool_key = 'gcp_channel'.getmypid();
+  if(apcu_exists($channel_pool_key)) {
+    echo "PFP_FPM GCP has been enabled. Reuse the config and the channel.\n";
+    $gcp_channel = apcu_fetch($channel_pool_key);
+    register_shutdown_function(function ($channel, $channel_pool_key) {
+      // Push the current gcp_channel back into the pool when the script finishes.
+      //  $global_conf['gcp_channel'.getmypid()] = $channel;
+      echo "register_shutdown_function ". $channel->version. "\n";
+      apcu_delete($channel_pool_key);
+      apcu_add($channel_pool_key, $channel);
+    }, $gcp_channel, $channel_pool_key);
+    $gcp_channel->reCreateCredentials();
+    $channel_interceptor = new \Grpc_gcp\GCPCallInterceptor($gcp_channel, $opts);
+    $channel = \Grpc\Interceptor::intercept($gcp_channel, $channel_interceptor);
+    return $channel;
+  } else {
+    $global_conf = parseConfObject($conf);
+    $opts_include_conf = array_merge($opts, ['global_conf' => $global_conf]);
+    $gcp_channel = new \Grpc_gcp\GrpcExtensionChannel($opts_include_conf);
+    $channel_interceptor = new \Grpc_gcp\GCPCallInterceptor($gcp_channel, $opts);
+    $channel = \Grpc\Interceptor::intercept($gcp_channel, $channel_interceptor);
+    apcu_add('gcp_channel' . getmypid(), $gcp_channel);
+    return $channel;
+  }
+}

--- a/src/php/lib/Grpc/GCP_extension/src/GCPCallInterceptor.php
+++ b/src/php/lib/Grpc/GCP_extension/src/GCPCallInterceptor.php
@@ -1,0 +1,232 @@
+<?php
+
+namespace Grpc_gcp;
+
+class GCPCallInterceptor extends \Grpc\Interceptor
+{
+
+  private $hostname_override;
+  private $update_metadata;
+  private $gcp_channel;
+  private $hostname;
+
+  public function __construct($gcp_channel, $opts) {
+    $this->gcp_channel = $gcp_channel;
+    $this->hostname = $gcp_channel->getTarget();
+    $this->update_metadata = $opts['update_metadata'];
+    $this->hostname_override = $opts['grpc.ssl_target_name_override'];
+  }
+
+  private function _get_jwt_aud_uri($method)
+  {
+    $last_slash_idx = strrpos($method, '/');
+    if ($last_slash_idx === false) {
+      throw new \InvalidArgumentException(
+        'service name must have a slash'
+      );
+    }
+    $service_name = substr($method, 0, $last_slash_idx);
+
+    if ($this->hostname_override) {
+      $hostname = $this->hostname_override;
+    } else {
+      $hostname = $this->hostname;
+    }
+    return 'https://'.$hostname.$service_name;
+  }
+
+  private function _validate_and_normalize_metadata($metadata)
+  {
+    $metadata_copy = [];
+    foreach ($metadata as $key => $value) {
+      if (!preg_match('/^[A-Za-z\d_-]+$/', $key)) {
+        throw new \InvalidArgumentException(
+          'Metadata keys must be nonempty strings containing only '.
+          'alphanumeric characters, hyphens and underscores'
+        );
+      }
+      $metadata_copy[strtolower($key)] = $value;
+    }
+    return $metadata_copy;
+  }
+
+  public function interceptUnaryUnary($method,
+                                      $argument,
+                                      $deserialize,
+                                      array $metadata = [],
+                                      array $options = [],
+                                      $continuation)
+  {
+    $call = new GCPUnaryCall($this->gcp_channel, $method, $deserialize, $options);
+    $jwt_aud_uri = $this->_get_jwt_aud_uri($method);
+    if (is_callable($this->update_metadata)) {
+      $metadata = call_user_func(
+        $this->update_metadata,
+        $metadata,
+        $jwt_aud_uri
+      );
+    }
+    $metadata = $this->_validate_and_normalize_metadata(
+      $metadata
+    );
+    var_dump($metadata);
+    $call->start($argument, $metadata, $options);
+    return $call;
+  }
+
+  public function interceptUnaryStream($method,
+                                       $argument,
+                                       $deserialize,
+                                       array $metadata = [],
+                                       array $options = [],
+                                       $continuation
+  ) {
+    $call = new GCPServerStreamCall($this->gcp_channel, $method, $deserialize, $options);
+    $jwt_aud_uri = $this->_get_jwt_aud_uri($method);
+    if (is_callable($this->update_metadata)) {
+      $metadata = call_user_func(
+        $this->update_metadata,
+        $metadata,
+        $jwt_aud_uri
+      );
+    }
+    $metadata = $this->_validate_and_normalize_metadata(
+      $metadata
+    );
+    var_dump($metadata);
+    $call->start($argument, $metadata, $options);
+    return $call;
+  }
+}
+
+abstract class GcpBaseCall
+{
+  protected $gcp_channel;
+  // It has the Grpc\Channel and related ref_count information for this RPC.
+  protected $channel_ref;
+  // If this RPC is 'UNBIND', use it instead of the one from response.
+  protected $affinity_key;
+  // Array of [affinity_key, command]
+  protected $_affinity;
+
+  // Information needed to create Grpc\Call object when the RPC starts.
+  protected $method;
+  protected $argument;
+  protected $metadata;
+  protected $options;
+
+  // Get all information needed to create a Call object and start the Call.
+  public function __construct($channel, $method, $deserialize, $options) {
+    echo "create GcpBaseCall\n";
+    $this->gcp_channel = $channel;
+    $this->method = $method;
+    $this->deserialize = $deserialize;
+    $this->options = $options;
+    $this->_affinity = null;
+    if (isset($this->gcp_channel->global_conf['affinity_by_method'][$method])) {
+      $this->_affinity = $this->gcp_channel->global_conf['affinity_by_method'][$method];
+    }
+  }
+
+  protected function rpcPreProcess($argument) {
+    $this->affinity_key = null;
+    if($this->_affinity) {
+      $command = $this->_affinity['command'];
+      if ($command == 'BOUND' || $command == 'UNBIND') {
+        $this->affinity_key = $this->getAffinityKeyFromProto($argument);
+      }
+    }
+    $this->channel_ref = $this->gcp_channel->getChannelRef($this->affinity_key);
+    $this->channel_ref->activeStreamRefIncr();
+    return $this->channel_ref;
+  }
+
+  protected function rpcPostProcess($status, $response) {
+    if($this->_affinity) {
+      $command = $this->_affinity['command'];
+      if ($command == 'BIND') {
+        if ($status->code != \Grpc\STATUS_OK) {
+          return;
+        }
+        $affinity_key = $this->getAffinityKeyFromProto($response);
+        $this->gcp_channel->_bind($this->channel_ref, $affinity_key);
+      } else if ($command == 'UNBIND') {
+        $this->gcp_channel->_unbind($this->affinity_key);
+      }
+    }
+    $this->channel_ref->activeStreamRefDecr();
+  }
+
+  protected function getAffinityKeyFromProto($proto) {
+    if($this->_affinity) {
+      $names = $this->_affinity['affinityKey'];
+      // TODO(ddyihai): names.split('.') because one RPC can have multiple affinityKey
+      $getAttrMethod = 'get'.ucfirst($names);
+      $affinity_key = call_user_func_array(array($proto, $getAttrMethod), array());
+      echo "[getAffinityKeyFromProto] $affinity_key\n";
+      return $affinity_key;
+    }
+  }
+}
+
+class GCPUnaryCall extends GcpBaseCall
+{
+  private function createRealCall($channel) {
+    $this->real_call = new \Grpc\UnaryCall($channel, $this->method, $this->deserialize, $this->options);
+    return $this->real_call;
+  }
+
+  // Public funtions are rewriting all methods inside UnaryCall
+  public function start($argument, $metadata, $options) {
+    $channel_ref = $this->rpcPreProcess($argument);
+    $real_channel = $channel_ref->getRealChannel($this->gcp_channel->credentials);
+    $this->real_call = $this->createRealCall($real_channel);
+    $this->real_call->start($argument, $metadata, $options);
+  }
+
+  public function wait() {
+    list($response, $status) = $this->real_call->wait();
+    $this->rpcPostProcess($status, $response);
+    return [$response, $status];
+  }
+
+  public function getMetadata() {
+    return $this->real_call->getMetadata();
+  }
+}
+
+class GCPServerStreamCall extends GcpBaseCall
+{
+  private $response = null;
+
+  private function createRealCall($channel) {
+    $this->real_call = new \Grpc\ServerStreamingCall($channel, $this->method, $this->deserialize, $this->options);
+    return $this->real_call;
+  }
+
+  public function start($argument, $metadata, $options) {
+    $channel_ref = $this->rpcPreProcess($argument);
+    $this->real_call = $this->createRealCall($channel_ref->getRealChannel(
+      $this->gcp_channel->credentials));
+    $this->real_call->start($argument, $metadata, $options);
+  }
+
+  public function responses() {
+    $response = $this->real_call->responses();
+    // Since the last response is empty for the server streaming RPC,
+    // the second last one is the last RPC response with payload.
+    // Use this one for searching the affinity key.
+    // The same as BidiStreaming.
+    if ($response) {
+      $this->response = $response;
+    }
+    return $response;
+  }
+
+  public function getStatus() {
+    $status = $this->real_call->getStatus();
+    $this->rpcPostProcess($status, $this->response);
+    return $status;
+  }
+}
+

--- a/src/php/lib/Grpc/GCP_extension/src/GCPExtensionChannel.php
+++ b/src/php/lib/Grpc/GCP_extension/src/GCPExtensionChannel.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace Grpc_gcp;
+
+class GrpcExtensionChannel
+{
+  public $max_size;
+  public $max_concurrent_streams_low_watermark;
+  public $target;
+  public $options;
+  public $affinity_by_method;
+  public $affinity_key_to_channel_ref;
+  public $channel_refs;
+  public $credentials;
+  public $global_conf;
+  // Version is used for debugging in PHP-FPM mode.
+  public $version;
+
+  public function getChannelRefs() {
+    return $this->channel_refs;
+  }
+
+  public function __construct($opts)
+  {
+    $this->version = 0;
+    $this->max_size = 10;
+    $this->max_concurrent_streams_low_watermark = 100;
+    if ($opts['global_conf']['channelPool']['maxSize']) {
+      $this->max_size = $opts['global_conf']['channelPool']['maxSize'];
+    }
+    if ($opts['global_conf']['channelPool']['maxConcurrentStreamsLowWatermark']) {
+      $this->max_concurrent_streams_low_watermark =
+          $opts['global_conf']['channelPool']['maxConcurrentStreamsLowWatermark'];
+    }
+    print_r($opts['global_conf']);
+    $this->target = $opts['global_conf']['target'][0];
+    $this->affinity_by_method = $opts['global_conf']['affinity_by_method'];
+    $this->affinity_key_to_channel_ref = array();
+    $this->channel_refs = array();
+    $this->global_conf = $opts['global_conf'];
+    $this->credentials = $opts['credentials'];
+    unset($opts['global_conf']);
+    unset($opts['credentials']);
+    unset($opts['update_metadata']);
+    $package_config = json_decode(
+      file_get_contents(dirname(__FILE__).'/../tests/composer.json'),
+      true
+    );
+    if (!empty($cur_opts['grpc.primary_user_agent'])) {
+      $opts['grpc.primary_user_agent'] .= ' ';
+    } else {
+      $opts['grpc.primary_user_agent'] = '';
+    }
+    $opts['grpc.primary_user_agent'] .=
+      'grpc-php/'.$package_config['version'];
+    $this->options = $opts;
+  }
+
+  public function reCreateCredentials() {
+    $this->version += 1;
+    $credentials = \Grpc\ChannelCredentials::createSsl();
+    $this->credentials = $credentials;
+  }
+
+  public function _bind($channel_ref, $affinity_key)
+  {
+    if (!array_key_exists($affinity_key, $this->affinity_key_to_channel_ref)) {
+      $this->affinity_key_to_channel_ref[$affinity_key] = $channel_ref;
+    }
+    $channel_ref->affinityRefIncr();
+    return $channel_ref;
+  }
+
+  public function _unbind($affinity_key)
+  {
+    $channel_ref = null;
+    if (array_key_exists($affinity_key, $this->affinity_key_to_channel_ref)) {
+      $channel_ref =  $this->affinity_key_to_channel_ref[$affinity_key];
+      $channel_ref->affinityRefDecr();
+    }
+    return $channel_ref;
+  }
+
+  function cmp_by_active_stream_ref($a, $b) {
+    return $a->getActiveStreamRef() - $b->getActiveStreamRef();
+  }
+
+
+  public function getChannelRef($affinity_key = null) {
+    if ($affinity_key) {
+      if (array_key_exists($affinity_key, $this->affinity_key_to_channel_ref)) {
+        return $this->affinity_key_to_channel_ref[$affinity_key];
+      }
+      return $this->getChannelRef();
+    }
+    usort($this->channel_refs, array($this, 'cmp_by_active_stream_ref'));
+
+    if(count($this->channel_refs) > 0 && $this->channel_refs[0]->getActiveStreamRef() <
+        $this->max_concurrent_streams_low_watermark) {
+      echo "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx". $this->channel_refs[0]->getActiveStreamRef(). " ". $this->max_concurrent_streams_low_watermark. "\n";
+        return $this->channel_refs[0];
+    }
+    $num_channel_refs = count($this->channel_refs);
+    if ($num_channel_refs < $this->max_size) {
+      $cur_opts = array_merge($this->options,
+        ['grpc_gcp_channel_id' => $num_channel_refs,
+          'grpc_target_persist_bound' => $this->max_size]);
+      $channel_ref = new _ChannelRef($this->target, $num_channel_refs, $cur_opts);
+      array_unshift($this->channel_refs, $channel_ref);
+    }
+    echo "[getChannelRef] channel_refs ";
+    return $this->channel_refs[0];
+  }
+
+  private function connectivityFunc($func, $args = null) {
+    $ready = 0;
+    $idle = 0;
+    $connecting = 0;
+    $transient_failure = 0;
+    $shutdown = 0;
+    foreach ($this->channel_refs as $channel_ref) {
+      switch ($channel_ref->$func($args)) {
+        case \Grpc\CHANNEL_READY:
+          $ready += 1;
+        case \Grpc\CHANNEL_SHUTDOWN:
+          $shutdown += 1;
+        case \Grpc\CHANNEL_CONNECTING:
+          $connecting += 1;
+        case \Grpc\CHANNEL_TRANSIENT_FAILURE:
+          $transient_failure += 1;
+        case \Grpc\CHANNEL_IDLE:
+          $idle += 1;
+      }
+    }
+    if ($ready > 0) {
+      return \Grpc\CHANNEL_READY;
+    } else if ($idle > 0) {
+      return \Grpc\CHANNEL_IDLE;
+    } else if ($connecting > 0) {
+      return \Grpc\CHANNEL_CONNECTING;
+    } else if ($transient_failure > 0) {
+      return \Grpc\CHANNEL_TRANSIENT_FAILURE;
+    } else if ($shutdown > 0) {
+      return \Grpc\CHANNEL_SHUTDOWN;
+    }
+  }
+
+  public function getConnectivityState($try_to_connect) {
+    return $this->connectivityFunc('getConnectivityState', $try_to_connect);
+  }
+
+  public function watchConnectivityState() {
+    return $this->connectivityFunc('watchConnectivityState');
+  }
+
+  public function getTarget() {
+    return $this->target;
+  }
+}

--- a/src/php/lib/Grpc/GCP_extension/tests/ActiveStreamTest.php
+++ b/src/php/lib/Grpc/GCP_extension/tests/ActiveStreamTest.php
@@ -1,0 +1,174 @@
+<?php
+
+
+require_once(dirname(__FILE__).'/vendor/autoload.php');
+require_once(dirname(__FILE__).'/../src/ChannelRef.php');
+require_once(dirname(__FILE__).'/../src/EnableGCP.php');
+require_once(dirname(__FILE__).'/../src/GCPCallInterceptor.php');
+require_once(dirname(__FILE__).'/../src/GCPExtensionChannel.php');
+require_once(dirname(__FILE__).'/generated/Grpc_gcp/ExtensionConfig.php');
+require_once(dirname(__FILE__).'/generated/Grpc_gcp/AffinityConfig.php');
+require_once(dirname(__FILE__).'/generated/Grpc_gcp/AffinityConfig_Command.php');
+require_once(dirname(__FILE__).'/generated/Grpc_gcp/ApiConfig.php');
+require_once(dirname(__FILE__).'/generated/Grpc_gcp/ChannelPoolConfig.php');
+require_once(dirname(__FILE__).'/generated/Grpc_gcp/MethodConfig.php');
+require_once(dirname(__FILE__).'/generated/GPBMetadata/GrpcGcp.php');
+
+use Google\Cloud\Spanner\V1\SpannerGrpcClient;
+use Google\Cloud\Spanner\V1\BeginTransactionRequest;
+use Google\Cloud\Spanner\V1\CommitRequest;
+use Google\Cloud\Spanner\V1\CommitResponse;
+use Google\Cloud\Spanner\V1\CreateSessionRequest;
+use Google\Cloud\Spanner\V1\DeleteSessionRequest;
+use Google\Cloud\Spanner\V1\ExecuteSqlRequest;
+use Google\Cloud\Spanner\V1\GetSessionRequest;
+use Google\Cloud\Spanner\V1\KeySet;
+use Google\Cloud\Spanner\V1\ListSessionsRequest;
+use Google\Cloud\Spanner\V1\ListSessionsResponse;
+use Google\Cloud\Spanner\V1\Mutation;
+use Google\Cloud\Spanner\V1\PartialResultSet;
+use Google\Cloud\Spanner\V1\PartitionOptions;
+use Google\Cloud\Spanner\V1\PartitionQueryRequest;
+use Google\Cloud\Spanner\V1\PartitionReadRequest;
+use Google\Cloud\Spanner\V1\PartitionResponse;
+use Google\Cloud\Spanner\V1\ReadRequest;
+use Google\Cloud\Spanner\V1\ResultSet;
+use Google\Cloud\Spanner\V1\RollbackRequest;
+use Google\Cloud\Spanner\V1\Session;
+use Google\Cloud\Spanner\V1\Transaction;
+use Google\Cloud\Spanner\V1\TransactionOptions;
+use Google\Cloud\Spanner\V1\TransactionSelector;
+use Google\Protobuf\GPBEmpty;
+use Google\Protobuf\Struct;
+
+use Google\Auth\ApplicationDefaultCredentials;
+
+$_WATER_MARK = 2;
+
+
+// Read GCP config.
+$string = file_get_contents("spanner.grpc.config");
+$conf = new Grpc_gcp\ExtensionConfig();
+$conf->mergeFromJsonString($string);
+$channel_pool = $conf->getApi()[0]->getChannelPool();
+$channel_pool->setMaxConcurrentStreamsLowWatermark($_WATER_MARK);
+// Options for creating the gRPC channel/stub.
+$credentials = \Grpc\ChannelCredentials::createSsl();
+$auth = ApplicationDefaultCredentials::getCredentials();
+$opts = [
+  'credentials' => $credentials,
+  'update_metadata' => $auth->getUpdateMetadataFunc(),
+];
+$hostname = 'spanner.googleapis.com';
+
+// Enable GCP.
+$gcp_channel = \Grpc_gcp\enableGrpcGcp($conf, $opts);
+$stub = new SpannerGrpcClient($hostname, $opts, $gcp_channel);
+
+$database = 'projects/grpc-gcp/instances/sample/databases/benchmark';
+$table = 'storage';
+$data = 'payload';
+
+function assertEqual($var1, $var2, $str = "") {
+  if ($var1 != $var2) {
+    throw new \Exception("$str $var1 not matches to $var2.\n");
+  }
+}
+function assertStatusOk($status) {
+  if ($status->code != \Grpc\STATUS_OK) {
+    var_dump($status);
+    throw new \Exception("gRPC status not OK: ".$status->code."\n");
+  }
+}
+
+// Test Concurrent Streams Watermark
+$sql_cmd = "select id from $table";
+$result = ['payload'];
+$exec_sql_calls = array();
+$sessions = array();
+for ($i=0; $i < $_WATER_MARK; $i++) {
+  $create_session_request = new CreateSessionRequest();
+  $create_session_request->setDatabase($database);
+  $create_session_call = $stub->CreateSession($create_session_request);
+  list($session, $status) = $create_session_call->wait();
+  assertStatusOk($status);
+  assertEqual(1, count($gcp_channel->getNext()->getChannelRefs()));
+  assertEqual($i + 1, $gcp_channel->getNext()->getChannelRefs()[0]->getAffinityRef());
+  assertEqual($i, $gcp_channel->getNext()->getChannelRefs()[0]->getActiveStreamRef());
+
+  $exec_sql_request = new ExecuteSqlRequest();
+  $exec_sql_request->setSession($session->getName());
+  $exec_sql_request->setSql($sql_cmd);
+  $exec_sql_call = $stub->ExecuteSql($exec_sql_request);
+  array_push($exec_sql_calls, $exec_sql_call);
+  array_push($sessions, $session);
+  assertEqual(1, count($gcp_channel->getNext()->getChannelRefs()));
+  assertEqual($i + 1, $gcp_channel->getNext()->getChannelRefs()[0]->getAffinityRef());
+  assertEqual($i + 1, $gcp_channel->getNext()->getChannelRefs()[0]->getActiveStreamRef());
+  print_r($gcp_channel->getNext()->getChannelRefs());
+}
+
+$create_session_request = new CreateSessionRequest();
+$create_session_request->setDatabase($database);
+$create_session_call = $stub->CreateSession($create_session_request);
+list($session, $status) = $create_session_call->wait();
+assertStatusOk($status);
+print_r($gcp_channel->getNext()->getChannelRefs());
+assertEqual(2, count($gcp_channel->getNext()->getChannelRefs()));
+assertEqual(2, $gcp_channel->getNext()->getChannelRefs()[1]->getAffinityRef());
+assertEqual(2, $gcp_channel->getNext()->getChannelRefs()[1]->getActiveStreamRef());
+assertEqual(1, $gcp_channel->getNext()->getChannelRefs()[0]->getAffinityRef());
+assertEqual(0, $gcp_channel->getNext()->getChannelRefs()[0]->getActiveStreamRef());
+
+// The new request uses the new session id.
+$exec_sql_request = new ExecuteSqlRequest();
+$exec_sql_request->setSession($session->getName());
+$exec_sql_request->setSql($sql_cmd);
+$exec_sql_call = $stub->ExecuteSql($exec_sql_request);
+assertEqual(2, count($gcp_channel->getNext()->getChannelRefs()));
+assertEqual(2, $gcp_channel->getNext()->getChannelRefs()[1]->getAffinityRef());
+assertEqual(2, $gcp_channel->getNext()->getChannelRefs()[1]->getActiveStreamRef());
+assertEqual(1, $gcp_channel->getNext()->getChannelRefs()[0]->getAffinityRef());
+assertEqual(1, $gcp_channel->getNext()->getChannelRefs()[0]->getActiveStreamRef());
+
+// Clear session and stream
+list($exec_sql_reply, $status) = $exec_sql_call->wait();
+assertStatusOk($status);
+assertEqual($exec_sql_reply->getRows()[0]->getValues()[0]->getStringValue(), $result[0]);
+assertEqual(2, count($gcp_channel->getNext()->getChannelRefs()));
+assertEqual(2, $gcp_channel->getNext()->getChannelRefs()[1]->getAffinityRef());
+assertEqual(2, $gcp_channel->getNext()->getChannelRefs()[1]->getActiveStreamRef());
+assertEqual(1, $gcp_channel->getNext()->getChannelRefs()[0]->getAffinityRef());
+assertEqual(0, $gcp_channel->getNext()->getChannelRefs()[0]->getActiveStreamRef());
+
+$delete_session_request = new DeleteSessionRequest();
+$delete_session_request->setName($session->getName());
+list($session, $status) = $stub->DeleteSession($delete_session_request)->wait();
+assertStatusOk($status);
+assertEqual(2, count($gcp_channel->getNext()->getChannelRefs()));
+assertEqual(2, $gcp_channel->getNext()->getChannelRefs()[1]->getAffinityRef());
+assertEqual(2, $gcp_channel->getNext()->getChannelRefs()[1]->getActiveStreamRef());
+assertEqual(0, $gcp_channel->getNext()->getChannelRefs()[0]->getAffinityRef());
+assertEqual(0, $gcp_channel->getNext()->getChannelRefs()[0]->getActiveStreamRef());
+
+for ($i=0; $i < $_WATER_MARK; $i++) {
+  list($exec_sql_reply, $status) = $exec_sql_calls[$i]->wait();
+  assertStatusOk($status);
+  assertEqual($exec_sql_reply->getRows()[0]->getValues()[0]->getStringValue(), $result[0]);
+  assertEqual(2, count($gcp_channel->getNext()->getChannelRefs()));
+  assertEqual(2 - $i, $gcp_channel->getNext()->getChannelRefs()[1]->getAffinityRef());
+  assertEqual(1 - $i, $gcp_channel->getNext()->getChannelRefs()[1]->getActiveStreamRef());
+  assertEqual(0, $gcp_channel->getNext()->getChannelRefs()[0]->getAffinityRef());
+  assertEqual(0, $gcp_channel->getNext()->getChannelRefs()[0]->getActiveStreamRef());
+
+  $delete_session_request = new DeleteSessionRequest();
+  $delete_session_request->setName($sessions[$i]->getName());
+  list($session, $status) = $stub->DeleteSession($delete_session_request)->wait();
+  assertEqual(2, count($gcp_channel->getNext()->getChannelRefs()));
+  assertEqual(1 - $i, $gcp_channel->getNext()->getChannelRefs()[1]->getAffinityRef());
+  assertEqual(1 - $i, $gcp_channel->getNext()->getChannelRefs()[1]->getActiveStreamRef());
+  assertEqual(0, $gcp_channel->getNext()->getChannelRefs()[0]->getAffinityRef());
+  assertEqual(0, $gcp_channel->getNext()->getChannelRefs()[0]->getActiveStreamRef());
+}
+
+

--- a/src/php/lib/Grpc/GCP_extension/tests/MultiChannelsTest.php
+++ b/src/php/lib/Grpc/GCP_extension/tests/MultiChannelsTest.php
@@ -1,0 +1,144 @@
+<?php
+
+
+require_once(dirname(__FILE__).'/vendor/autoload.php');
+require_once(dirname(__FILE__).'/../src/ChannelRef.php');
+require_once(dirname(__FILE__).'/../src/EnableGCP.php');
+require_once(dirname(__FILE__).'/../src/GCPCallInterceptor.php');
+require_once(dirname(__FILE__).'/../src/GCPExtensionChannel.php');
+require_once(dirname(__FILE__).'/generated/Grpc_gcp/ExtensionConfig.php');
+require_once(dirname(__FILE__).'/generated/Grpc_gcp/AffinityConfig.php');
+require_once(dirname(__FILE__).'/generated/Grpc_gcp/AffinityConfig_Command.php');
+require_once(dirname(__FILE__).'/generated/Grpc_gcp/ApiConfig.php');
+require_once(dirname(__FILE__).'/generated/Grpc_gcp/ChannelPoolConfig.php');
+require_once(dirname(__FILE__).'/generated/Grpc_gcp/MethodConfig.php');
+require_once(dirname(__FILE__).'/generated/GPBMetadata/GrpcGcp.php');
+
+use Google\Cloud\Spanner\V1\SpannerGrpcClient;
+use Google\Cloud\Spanner\V1\BeginTransactionRequest;
+use Google\Cloud\Spanner\V1\CommitRequest;
+use Google\Cloud\Spanner\V1\CommitResponse;
+use Google\Cloud\Spanner\V1\CreateSessionRequest;
+use Google\Cloud\Spanner\V1\DeleteSessionRequest;
+use Google\Cloud\Spanner\V1\ExecuteSqlRequest;
+use Google\Cloud\Spanner\V1\GetSessionRequest;
+use Google\Cloud\Spanner\V1\KeySet;
+use Google\Cloud\Spanner\V1\ListSessionsRequest;
+use Google\Cloud\Spanner\V1\ListSessionsResponse;
+use Google\Cloud\Spanner\V1\Mutation;
+use Google\Cloud\Spanner\V1\PartialResultSet;
+use Google\Cloud\Spanner\V1\PartitionOptions;
+use Google\Cloud\Spanner\V1\PartitionQueryRequest;
+use Google\Cloud\Spanner\V1\PartitionReadRequest;
+use Google\Cloud\Spanner\V1\PartitionResponse;
+use Google\Cloud\Spanner\V1\ReadRequest;
+use Google\Cloud\Spanner\V1\ResultSet;
+use Google\Cloud\Spanner\V1\RollbackRequest;
+use Google\Cloud\Spanner\V1\Session;
+use Google\Cloud\Spanner\V1\Transaction;
+use Google\Cloud\Spanner\V1\TransactionOptions;
+use Google\Cloud\Spanner\V1\TransactionSelector;
+use Google\Protobuf\GPBEmpty;
+use Google\Protobuf\Struct;
+
+use Google\Auth\ApplicationDefaultCredentials;
+
+// Read GCP config.
+$string = file_get_contents("spanner.grpc.config");
+$conf = new Grpc_gcp\ExtensionConfig();
+$conf->mergeFromJsonString($string);
+// Options for creating the gRPC channel/stub.
+$credentials = \Grpc\ChannelCredentials::createSsl();
+$auth = ApplicationDefaultCredentials::getCredentials();
+$opts = [
+  'credentials' => $credentials,
+  'update_metadata' => $auth->getUpdateMetadataFunc(),
+];
+$hostname = 'spanner.googleapis.com';
+
+// Enable GCP.
+$gcp_channel = \Grpc_gcp\enableGrpcGcp($conf, $opts);
+$stub = new SpannerGrpcClient($hostname, $opts, $gcp_channel);
+
+$database = 'projects/grpc-gcp/instances/sample/databases/benchmark';
+$table = 'storage';
+$data = 'payload';
+
+
+function assertEqual($var1, $var2, $str = "") {
+  if ($var1 != $var2) {
+    throw new \Exception("$str $var1 not matches to $var2.\n");
+  }
+}
+function assertStatusOk($status) {
+  if ($status->code != \Grpc\STATUS_OK) {
+    var_dump($status);
+    throw new \Exception("gRPC status not OK: ".$status->code."\n");
+  }
+}
+
+$_DEFAULT_MAX_CHANNELS_PER_TARGET = 2;
+
+// Test CreateSession Reuse Channel
+for ($i=0; $i<$_DEFAULT_MAX_CHANNELS_PER_TARGET; $i++){
+  echo "===================================================\n";
+  $create_session_request = new CreateSessionRequest();
+  $create_session_request->setDatabase($database);
+  $create_session_call = $stub->CreateSession($create_session_request);
+  list($session, $status) = $create_session_call->wait();
+  assertStatusOk($status);
+  $delete_session_request = new DeleteSessionRequest();
+  $delete_session_request->setName($session->getName());
+  list($session, $status) = $stub->DeleteSession($delete_session_request)->wait();
+  assertStatusOk($status);
+  $result = (count($gcp_channel->getNext()->getChannelRefs()) == 1);
+  assertEqual(1, count($gcp_channel->getNext()->getChannelRefs()));
+}
+print_r($gcp_channel->getNext()->getChannelRefs());
+
+
+// Test CreateSession New Channel
+$rpc_calls = array();
+for ($i=0; $i<$_DEFAULT_MAX_CHANNELS_PER_TARGET; $i++){
+  $create_session_request = new CreateSessionRequest();
+  $create_session_request->setDatabase($database);
+  $create_session_call = $stub->CreateSession($create_session_request);
+  $result = (count($gcp_channel->getNext()->getChannelRefs()) == $i+1);
+  print_r($gcp_channel->getNext()->getChannelRefs());
+  assertEqual($i+1, count($gcp_channel->getNext()->getChannelRefs()));
+  array_push($rpc_calls, $create_session_call);
+}
+for ($i=0; $i<$_DEFAULT_MAX_CHANNELS_PER_TARGET; $i++) {
+  list($session, $status) = $rpc_calls[$i]->wait();
+  assertStatusOk($status);
+  $delete_session_request = new DeleteSessionRequest();
+  $delete_session_request->setName($session->getName());
+  $delete_session_call = $stub->DeleteSession($delete_session_request);
+  list($session, $status) = $delete_session_call->wait();
+  assertStatusOk($status);
+  $result = (count($gcp_channel->getNext()->getChannelRefs()) == $_DEFAULT_MAX_CHANNELS_PER_TARGET);
+  assertEqual($_DEFAULT_MAX_CHANNELS_PER_TARGET,
+      count($gcp_channel->getNext()->getChannelRefs()));
+}
+
+$rpc_calls = array();
+for ($i=0; $i<$_DEFAULT_MAX_CHANNELS_PER_TARGET; $i++){
+  echo "feature =================================\n";
+  $create_session_request = new CreateSessionRequest();
+  $create_session_request->setDatabase($database);
+  $create_session_call = $stub->CreateSession($create_session_request);
+  $result = (count($gcp_channel->getNext()->getChannelRefs()) == $_DEFAULT_MAX_CHANNELS_PER_TARGET);
+  assertEqual($_DEFAULT_MAX_CHANNELS_PER_TARGET,
+      count($gcp_channel->getNext()->getChannelRefs()));
+  array_push($rpc_calls, $create_session_call);
+}
+for ($i=0; $i<$_DEFAULT_MAX_CHANNELS_PER_TARGET; $i++) {
+  list($session, $status) = $rpc_calls[$i]->wait();
+  $delete_session_request = new DeleteSessionRequest();
+  $delete_session_request->setName($session->getName());
+  list($session, $status) = $stub->DeleteSession($delete_session_request)->wait();
+  assertStatusOk($status);
+}
+//print_r($gcp_channel->getNext()->getChannelRefs());
+
+

--- a/src/php/lib/Grpc/GCP_extension/tests/UnaryStreamCallTest.php
+++ b/src/php/lib/Grpc/GCP_extension/tests/UnaryStreamCallTest.php
@@ -1,0 +1,184 @@
+<?php
+
+
+require_once(dirname(__FILE__).'/vendor/autoload.php');
+require_once(dirname(__FILE__).'/../src/ChannelRef.php');
+require_once(dirname(__FILE__).'/../src/EnableGCP.php');
+require_once(dirname(__FILE__).'/../src/GCPCallInterceptor.php');
+require_once(dirname(__FILE__).'/../src/GCPExtensionChannel.php');
+require_once(dirname(__FILE__).'/generated/Grpc_gcp/ExtensionConfig.php');
+require_once(dirname(__FILE__).'/generated/Grpc_gcp/AffinityConfig.php');
+require_once(dirname(__FILE__).'/generated/Grpc_gcp/AffinityConfig_Command.php');
+require_once(dirname(__FILE__).'/generated/Grpc_gcp/ApiConfig.php');
+require_once(dirname(__FILE__).'/generated/Grpc_gcp/ChannelPoolConfig.php');
+require_once(dirname(__FILE__).'/generated/Grpc_gcp/MethodConfig.php');
+require_once(dirname(__FILE__).'/generated/GPBMetadata/GrpcGcp.php');
+
+use Google\Cloud\Spanner\V1\SpannerGrpcClient;
+use Google\Cloud\Spanner\V1\BeginTransactionRequest;
+use Google\Cloud\Spanner\V1\CommitRequest;
+use Google\Cloud\Spanner\V1\CommitResponse;
+use Google\Cloud\Spanner\V1\CreateSessionRequest;
+use Google\Cloud\Spanner\V1\DeleteSessionRequest;
+use Google\Cloud\Spanner\V1\ExecuteSqlRequest;
+use Google\Cloud\Spanner\V1\GetSessionRequest;
+use Google\Cloud\Spanner\V1\KeySet;
+use Google\Cloud\Spanner\V1\ListSessionsRequest;
+use Google\Cloud\Spanner\V1\ListSessionsResponse;
+use Google\Cloud\Spanner\V1\Mutation;
+use Google\Cloud\Spanner\V1\PartialResultSet;
+use Google\Cloud\Spanner\V1\PartitionOptions;
+use Google\Cloud\Spanner\V1\PartitionQueryRequest;
+use Google\Cloud\Spanner\V1\PartitionReadRequest;
+use Google\Cloud\Spanner\V1\PartitionResponse;
+use Google\Cloud\Spanner\V1\ReadRequest;
+use Google\Cloud\Spanner\V1\ResultSet;
+use Google\Cloud\Spanner\V1\RollbackRequest;
+use Google\Cloud\Spanner\V1\Session;
+use Google\Cloud\Spanner\V1\Transaction;
+use Google\Cloud\Spanner\V1\TransactionOptions;
+use Google\Cloud\Spanner\V1\TransactionSelector;
+use Google\Protobuf\GPBEmpty;
+use Google\Protobuf\Struct;
+
+use Google\Auth\ApplicationDefaultCredentials;
+
+// Read GCP config.
+$string = file_get_contents("spanner.grpc.config");
+$conf = new Grpc_gcp\ExtensionConfig();
+$conf->mergeFromJsonString($string);
+// Options for creating the gRPC channel/stub.
+$credentials = \Grpc\ChannelCredentials::createSsl();
+$auth = ApplicationDefaultCredentials::getCredentials();
+$opts = [
+  'credentials' => $credentials,
+  'update_metadata' => $auth->getUpdateMetadataFunc(),
+];
+$hostname = 'spanner.googleapis.com';
+
+// Enable GCP.
+$gcp_channel = \Grpc_gcp\enableGrpcGcp($conf, $opts);
+$stub = new SpannerGrpcClient($hostname, $opts, $gcp_channel);
+
+$database = 'projects/grpc-gcp/instances/sample/databases/benchmark';
+$table = 'storage';
+$data = 'payload';
+
+
+function assertEqual($var1, $var2, $str = "") {
+  if ($var1 != $var2) {
+    throw new \Exception("$str $var1 not matches to $var2.\n");
+  }
+}
+function assertStatusOk($status) {
+  if ($status->code != \Grpc\STATUS_OK) {
+    var_dump($status);
+    throw new \Exception("gRPC status not OK: ".$status->code."\n");
+  }
+}
+
+$_DEFAULT_MAX_CHANNELS_PER_TARGET = 10;
+
+// Test Create List Delete Session
+$create_session_request = new CreateSessionRequest();
+$create_session_request->setDatabase($database);
+$create_session_call = $stub->CreateSession($create_session_request);
+list($session, $status) = $create_session_call->wait();
+assertStatusOk($status);
+assertEqual(1, count($gcp_channel->getNext()->getChannelRefs()));
+assertEqual(1, $gcp_channel->getNext()->getChannelRefs()[0]->getAffinityRef());
+assertEqual(0, $gcp_channel->getNext()->getChannelRefs()[0]->getActiveStreamRef());
+
+$list_session_request = new ListSessionsRequest();
+$list_session_request->setDatabase($database);
+$list_session_call = $stub->ListSessions($list_session_request);
+list($list_session_response, $status) = $list_session_call->wait();
+assertStatusOk($status);
+//foreach ($list_session_response->getSessions() as $session) {
+//  echo "session:\n";
+//  echo "name - ". $session->getName(). PHP_EOL;
+//}
+assertEqual(1, count($gcp_channel->getNext()->getChannelRefs()));
+assertEqual(1, $gcp_channel->getNext()->getChannelRefs()[0]->getAffinityRef());
+assertEqual(0, $gcp_channel->getNext()->getChannelRefs()[0]->getActiveStreamRef());
+
+$delete_session_request = new DeleteSessionRequest();
+$delete_session_request->setName($session->getName());
+list($delete_session_response, $status) = $stub->DeleteSession($delete_session_request)->wait();
+assertStatusOk($status);
+assertEqual(1, count($gcp_channel->getNext()->getChannelRefs()));
+assertEqual(0, $gcp_channel->getNext()->getChannelRefs()[0]->getAffinityRef());
+assertEqual(0, $gcp_channel->getNext()->getChannelRefs()[0]->getActiveStreamRef());
+
+$list_session_request = new ListSessionsRequest();
+$list_session_request->setDatabase($database);
+$list_session_call = $stub->ListSessions($list_session_request);
+list($list_session_response, $status) = $list_session_call->wait();
+assertStatusOk($status);
+assertEqual(1, count($gcp_channel->getNext()->getChannelRefs()));
+assertEqual(0, $gcp_channel->getNext()->getChannelRefs()[0]->getAffinityRef());
+assertEqual(0, $gcp_channel->getNext()->getChannelRefs()[0]->getActiveStreamRef());
+
+// Test eExecute Sql
+$create_session_request = new CreateSessionRequest();
+$create_session_request->setDatabase($database);
+$create_session_call = $stub->CreateSession($create_session_request);
+list($session, $status) = $create_session_call->wait();
+assertEqual(1, count($gcp_channel->getNext()->getChannelRefs()));
+assertEqual(1, $gcp_channel->getNext()->getChannelRefs()[0]->getAffinityRef());
+assertEqual(0, $gcp_channel->getNext()->getChannelRefs()[0]->getActiveStreamRef());
+
+$sql_cmd = "select id from $table";
+$exec_sql_request = new ExecuteSqlRequest();
+$exec_sql_request->setSession($session->getName());
+$exec_sql_request->setSql($sql_cmd);
+$exec_sql_call = $stub->ExecuteSql($exec_sql_request);
+list($exec_sql_reply, $status) = $exec_sql_call->wait();
+assertStatusOk($status);
+assertEqual(1, count($gcp_channel->getNext()->getChannelRefs()));
+assertEqual(1, $gcp_channel->getNext()->getChannelRefs()[0]->getAffinityRef());
+assertEqual(0, $gcp_channel->getNext()->getChannelRefs()[0]->getActiveStreamRef());
+$result = ['payload'];
+$i = 0;
+
+foreach ($exec_sql_reply->getRows() as $row) {
+  foreach($row->getValues() as $value) {
+    assertEqual($value->getStringValue(), $result[$i]);
+    $i += 1;
+  }
+}
+
+$delete_session_request = new DeleteSessionRequest();
+$delete_session_request->setName($session->getName());
+list($delete_session_response, $status) = $stub->DeleteSession($delete_session_request)->wait();
+assertStatusOk($status);
+assertEqual(1, count($gcp_channel->getNext()->getChannelRefs()));
+assertEqual(0, $gcp_channel->getNext()->getChannelRefs()[0]->getAffinityRef());
+assertEqual(0, $gcp_channel->getNext()->getChannelRefs()[0]->getActiveStreamRef());
+
+// Test Execute Streaming Sql
+$create_session_request = new CreateSessionRequest();
+$create_session_request->setDatabase($database);
+$create_session_call = $stub->CreateSession($create_session_request);
+list($session, $status) = $create_session_call->wait();
+assertEqual(1, count($gcp_channel->getNext()->getChannelRefs()));
+assertEqual(1, $gcp_channel->getNext()->getChannelRefs()[0]->getAffinityRef());
+assertEqual(0, $gcp_channel->getNext()->getChannelRefs()[0]->getActiveStreamRef());
+
+$sql_cmd = "select id from $table";
+$stream_exec_sql_request = new ExecuteSqlRequest();
+$stream_exec_sql_request->setSession($session->getName());
+$stream_exec_sql_request->setSql($sql_cmd);
+$stream_exec_sql_call = $stub->ExecuteStreamingSql($stream_exec_sql_request);
+$features = $stream_exec_sql_call->responses();
+$result = ['payload'];
+$i = 0;
+foreach ($features as $feature) {
+  foreach ($feature->getValues() as $value) {
+    assertEqual($value->getStringValue(), $result[$i]);
+    $i += 1;
+  }
+}
+$status = $stream_exec_sql_call->getStatus();
+assertStatusOk($status);
+

--- a/src/php/lib/Grpc/GCP_extension/tests/composer.json
+++ b/src/php/lib/Grpc/GCP_extension/tests/composer.json
@@ -1,0 +1,23 @@
+{
+  "name": "grpc/grpc-dev",
+  "description": "gRPC library for PHP - for Developement use only",
+  "license": "Apache-2.0",
+  "version": "1.13.0",
+  "require": {
+    "php": ">=5.5.0",
+    "google/protobuf": "^v3.3.0",
+    "google/auth": "^1.3",
+    "google/gax": "^0.33.0",
+    "google/cloud": "^0.67.0"
+  },
+  "require-dev": {
+  },
+  "autoload": {
+    "psr-4": {
+      "Grpc\\": "lib/Grpc/",
+      "Grpc_gcp\\": "lib/Grpc_gcp/",
+      "": ["tests/interop/",
+           "tests/generated_code/"]
+    }
+  }
+}

--- a/src/php/lib/Grpc/GCP_extension/tests/grpc_gcp.proto
+++ b/src/php/lib/Grpc/GCP_extension/tests/grpc_gcp.proto
@@ -1,0 +1,77 @@
+// Copyright 2018 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package grpc_gcp;
+
+message ExtensionConfig {
+  repeated ApiConfig api = 1;
+}
+
+message ApiConfig {
+  // A list of targets point to the same API endpoint.
+  repeated string target = 1;
+
+  // The channel pool configurations.
+  ChannelPoolConfig channel_pool = 2;
+
+  // The method configurations.
+  repeated MethodConfig method = 1001;
+}
+
+message ChannelPoolConfig {
+  // The max number of channels in the pool.
+  uint32 max_size = 1;
+  // The idle timeout (seconds) of channels without bound affinity sessions.
+  uint64 idle_timeout = 2;
+  // The low watermark of max number of concurrent streams in a channel.
+  // New channel will be created once it get hit, until we reach the max size
+  // of the channel pool.
+  uint32 max_concurrent_streams_low_watermark = 3;
+}
+
+message MethodConfig {
+  // A fully qualified name of a gRPC method, or a wildcard pattern ending
+  // with .*, such as foo.bar.A, foo.bar.*. Method configs are evaluated
+  // sequentially, and the first one takes precedence.
+  repeated string name = 1;
+
+  // The channel affinity configurations.
+  AffinityConfig affinity = 1001;
+}
+
+message AffinityConfig {
+  enum Command {
+    // The annotated method will be required to be bound to an existing session
+    // to execute the RPC. The corresponding <affinity_key_field_path> will be
+    // used to find the affinity key from the request message.
+    BOUND = 0;
+    // The annotated method will establish the channel affinity with the channel
+    // which is used to execute the RPC. The corresponding
+    // <affinity_key_field_path> will be used to find the affinity key from the
+    // response message.
+    BIND = 1;
+    // The annotated method will remove the channel affinity with the channel
+    // which is used to execute the RPC. The corresponding
+    // <affinity_key_field_path> will be used to find the affinity key from the
+    // request message.
+    UNBIND = 2;
+  }
+  // The affinity command applies on the selected gRPC methods.
+  Command command = 2;
+  // The field path of the affinity key in the request/response message.
+  // For example: "f.a", "f.b.d", etc.
+  string affinity_key = 3;
+}

--- a/src/php/lib/Grpc/GCP_extension/tests/spanner.grpc.config
+++ b/src/php/lib/Grpc/GCP_extension/tests/spanner.grpc.config
@@ -1,0 +1,34 @@
+{
+  "api":[
+    {
+    "target":["spanner.googleapis.com","spanner.googleapis.com:443"],
+    "channelPool":{"maxSize":10,"maxConcurrentStreamsLowWatermark":1},
+    "method":[
+      {"name":["/google.spanner.v1.Spanner/CreateSession"],
+        "affinity":{"command":"BIND", "affinityKey":"name"}},
+      {"name":["/google.spanner.v1.Spanner/GetSession"],
+        "affinity":{"command":"BOUND", "affinityKey":"name"}},
+      {"name":["/google.spanner.v1.Spanner/DeleteSession"],
+        "affinity":{"command":"UNBIND", "affinityKey":"name"}},
+      {"name":["/google.spanner.v1.Spanner/ExecuteSql"],
+        "affinity":{"command":"BOUND", "affinityKey":"session"}},
+      {"name":["/google.spanner.v1.Spanner/ExecuteStreamingSql"],
+        "affinity":{"command":"BOUND", "affinityKey":"session"}},
+      {"name":["/google.spanner.v1.Spanner/Read"],
+        "affinity":{"command":"BOUND", "affinityKey":"session"}},
+      {"name":["/google.spanner.v1.Spanner/StreamingRead"],
+        "affinity":{"command":"BOUND", "affinityKey":"session"}},
+      {"name":["/google.spanner.v1.Spanner/BeginTransaction"],
+        "affinity":{"command":"BOUND", "affinityKey":"session"}},
+      {"name":["/google.spanner.v1.Spanner/Commit"],
+        "affinity":{"command":"BOUND", "affinityKey":"session"}},
+      {"name":["/google.spanner.v1.Spanner/Rollback"],
+        "affinity":{"command":"BOUND", "affinityKey":"session"}},
+      {"name":["/google.spanner.v1.Spanner/PartitionQuery"],
+        "affinity":{"command":"BOUND", "affinityKey":"session"}},
+      {"name":["/google.spanner.v1.Spanner/PartitionRead"],
+        "affinity":{"command":"BOUND", "affinityKey":"session"}}
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Status: draft; Works under PHP-FPM mode.

Attempt to solve the issue https://github.com/grpc/grpc/issues/15426. I am trying to solve it like a plugin/extension, so later if there are other feature needed, we can easily extend this plugin/extension or implement a new plugin/extension.

The implementation depends on 1 API changes inside grpc:
`add deserialize into the interceptor argument` https://github.com/grpc/grpc/pull/15779

usage:
```
// prepare
$conf = new Grpc_gcp\ExtensionConfig();
$conf->mergeFromJsonString($file_path);
$channel_pool = $conf->getApi()[0]->getChannelPool();
$channel_pool->setMaxConcurrentStreamsLowWatermark($_WATER_MARK);
// Options for creating the gRPC channel/stub.
$credentials = \Grpc\ChannelCredentials::createSsl();
$auth = ApplicationDefaultCredentials::getCredentials();
$opts = [
  'credentials' => $credentials,
  'update_metadata' => $auth->getUpdateMetadataFunc(),
];
$hostname = 'spanner.googleapis.com';

// Enable GCP.
$gcp_channel = \Grpc_gcp\enableGrpcGcp($conf, $opts);
$stub = new SpannerGrpcClient($hostname, $opts, $gcp_channel);
```